### PR TITLE
feat: Added ledgerconfig update sub-command

### DIFF
--- a/cmd/ledgerconfig/common/basecmd.go
+++ b/cmd/ledgerconfig/common/basecmd.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package common
 
 import (
+	"bufio"
 	"fmt"
 
 	"github.com/hyperledger/fabric-cli/cmd/common"
@@ -57,4 +58,29 @@ func (c *BaseCommand) Context() *environment.Context {
 func (c *BaseCommand) Fprintln(arg ...interface{}) error {
 	_, err := fmt.Fprintln(c.Settings.Streams.Out, arg...)
 	return err
+}
+
+// FprintlnOrPanic displays the given args to the configured output stream.
+// If an error occurs then this function panics.
+func (c *BaseCommand) FprintlnOrPanic(arg ...interface{}) {
+	if _, err := fmt.Fprintln(c.Settings.Streams.Out, arg...); err != nil {
+		panic(err.Error())
+	}
+}
+
+// Prompt waits for the user to enter a string and returns the string
+func (c *BaseCommand) Prompt() string {
+	ackChan := make(chan string)
+	go c.readFromTerminal(ackChan)
+	ack := <-ackChan
+	return ack
+}
+
+func (c *BaseCommand) readFromTerminal(responsech chan string) {
+	reader := bufio.NewReader(c.Settings.Streams.In)
+	if response, err := reader.ReadString('\n'); err != nil {
+		c.FprintlnOrPanic(fmt.Sprintf("Error reading from terminal: %s", err))
+	} else {
+		responsech <- response[0:1]
+	}
 }

--- a/cmd/ledgerconfig/common/config.go
+++ b/cmd/ledgerconfig/common/config.go
@@ -1,0 +1,54 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+// Format specifies the format of the configuration
+type Format string
+
+// Config contains zero or more application configurations and zero or more peer-specific application configurations
+type Config struct {
+	// MspID is the ID of the MSP
+	MspID string
+	// Peers contains configuration for zero or more peers
+	Peers []*Peer `json:",omitempty"`
+	// Apps contains configuration for zero or more application
+	Apps []*App `json:",omitempty"`
+}
+
+// Peer contains a collection of application configurations for a given peer
+type Peer struct {
+	// PeerID is the unique ID of the peer
+	PeerID string
+	// Apps contains configuration for one or more application
+	Apps []*App
+}
+
+// App contains the configuration for an application and/or multiple sub-components.
+type App struct {
+	// Name is the name of the application
+	AppName string
+	// Version is the version of the config
+	Version string
+	// Format describes the format of the data
+	Format Format
+	// Config contains the actual configuration
+	Config string
+	// Components zero or more component configs
+	Components []*Component `json:",omitempty"`
+}
+
+// Component contains the configuration for an application component.
+type Component struct {
+	// Name is the name of the component
+	Name string
+	// Version is the version of the config
+	Version string
+	// Format describes the format of the data
+	Format Format
+	// Config contains the actual configuration
+	Config string
+}

--- a/cmd/ledgerconfig/ledgerconfig.go
+++ b/cmd/ledgerconfig/ledgerconfig.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hyperledger/fabric-cli/pkg/environment"
 	"github.com/spf13/cobra"
 	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/querycmd"
+	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/updatecmd"
 )
 
 const (
@@ -30,6 +31,7 @@ func New(settings *environment.Settings) *cobra.Command {
 	}
 	cmd.AddCommand(
 		querycmd.New(settings),
+		updatecmd.New(settings),
 	)
 	return cmd
 }

--- a/cmd/ledgerconfig/ledgerconfig_test.go
+++ b/cmd/ledgerconfig/ledgerconfig_test.go
@@ -27,5 +27,7 @@ func TestNew(t *testing.T) {
 	require.NoError(t, err)
 
 	// Make sure that the query command was added
-	require.Contains(t, w.Written(), "Query ledger configurationFlags")
+	require.Contains(t, w.Written(), "Query ledger configuration")
+	// Make sure that the update command was added
+	require.Contains(t, w.Written(), "Update ledger configuration")
 }

--- a/cmd/ledgerconfig/mocks/reader.go
+++ b/cmd/ledgerconfig/mocks/reader.go
@@ -1,0 +1,17 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+// Reader provides a byte array from which the reader reads
+type Reader struct {
+	Bytes []byte
+}
+
+// Read reads from the byte array
+func (r *Reader) Read(p []byte) (n int, err error) {
+	return copy(p, r.Bytes), nil
+}

--- a/cmd/ledgerconfig/mocks/writer.go
+++ b/cmd/ledgerconfig/mocks/writer.go
@@ -13,11 +13,15 @@ import (
 // Writer captures the written bytes so that they may be examined in unit tests
 type Writer struct {
 	Bytes []byte
+	Err   error
 }
 
 // Write saves the given bytes
 func (w *Writer) Write(p []byte) (int, error) {
-	w.Bytes = p
+	if w.Err != nil {
+		return 0, w.Err
+	}
+	w.Bytes = append(w.Bytes, p...)
 	return len(p), nil
 }
 

--- a/cmd/ledgerconfig/querycmd/querycmd.go
+++ b/cmd/ledgerconfig/querycmd/querycmd.go
@@ -115,6 +115,7 @@ func newCmd(settings *environment.Settings, p common.FactoryProvider) *cobra.Com
 
 	c.Settings = settings
 	cmd.SetOutput(c.Settings.Streams.Out)
+	cmd.SilenceUsage = true
 
 	cmd.Flags().StringVar(&c.criteriaStr, criteriaFlag, "", criteriaUsage)
 	cmd.Flags().StringVar(&c.mspID, mspIDFlag, "", mspIDUsage)

--- a/cmd/ledgerconfig/sampleconfig/absolute-refs-config.json
+++ b/cmd/ledgerconfig/sampleconfig/absolute-refs-config.json
@@ -1,0 +1,11 @@
+{
+  "MspID": "Org1MSP",
+  "Apps": [
+    {
+      "AppName": "app1",
+      "Version": "1",
+      "Format": "JSON",
+      "Config": "file:///usr/local/backup/file-not-there.json"
+    }
+  ]
+}

--- a/cmd/ledgerconfig/sampleconfig/invalid-refs-config.json
+++ b/cmd/ledgerconfig/sampleconfig/invalid-refs-config.json
@@ -1,0 +1,11 @@
+{
+  "MspID": "Org1MSP",
+  "Apps": [
+    {
+      "AppName": "app1",
+      "Version": "1",
+      "Format": "JSON",
+      "Config": "file://./file-not-there.json"
+    }
+  ]
+}

--- a/cmd/ledgerconfig/sampleconfig/org1-app3.json
+++ b/cmd/ledgerconfig/sampleconfig/org1-app3.json
@@ -1,0 +1,4 @@
+{
+  "key1":"value1 for org1-app3",
+  "key2":"value2 for org1-app3"
+}

--- a/cmd/ledgerconfig/sampleconfig/org1-app4-comp1.yaml
+++ b/cmd/ledgerconfig/sampleconfig/org1-app4-comp1.yaml
@@ -1,0 +1,8 @@
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#############################################################
+
+app1config:
+  key1: value1 for org1-app4-comp1
+  key2: value2 for org1-app4-comp1

--- a/cmd/ledgerconfig/sampleconfig/org1-app4-comp2.yaml
+++ b/cmd/ledgerconfig/sampleconfig/org1-app4-comp2.yaml
@@ -1,0 +1,8 @@
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#############################################################
+
+app1config:
+  key1: value1 for org1-app4-comp2
+  key2: value2 for org1-app4-comp2

--- a/cmd/ledgerconfig/sampleconfig/org1-config.json
+++ b/cmd/ledgerconfig/sampleconfig/org1-config.json
@@ -1,0 +1,71 @@
+{
+  "MspID": "Org1MSP",
+  "Peers": [
+    {
+      "PeerID": "peer0.org1.com",
+      "Apps": [
+        {
+          "AppName": "app1",
+          "Version": "1",
+          "Format": "YAML",
+          "Config": "file://./org1-peer0-app1.yaml"
+        },
+        {
+          "AppName": "app2",
+          "Version": "1",
+          "Format": "JSON",
+          "Config": "file://./org1-peer0-app2.json"
+        }
+      ]
+    },
+    {
+      "PeerID": "peer1.org1.com",
+      "Apps": [
+        {
+          "AppName": "app1",
+          "Version": "1",
+          "Format": "YAML",
+          "Config": "file://./org1-peer1-app1.yaml"
+        },
+        {
+          "AppName": "app2",
+          "Version": "1",
+          "Format": "JSON",
+          "Config": "file://./org1-peer1-app2.json"
+        }
+      ]
+    }
+  ],
+  "Apps": [
+    {
+      "AppName": "app3",
+      "Version": "1",
+      "Format": "JSON",
+      "Config": "file://./org1-app3.json"
+    },
+    {
+      "AppName": "app4",
+      "Version": "1",
+      "Components": [
+        {
+          "Name": "comp1",
+          "Version": "v1",
+          "Format": "YAML",
+          "Config": "file://./org1-app4-comp1.yaml"
+        },
+        {
+          "Name": "comp2",
+          "Version": "v1",
+          "Format": "YAML",
+          "Config": "file://./org1-app4-comp2.yaml"
+        }
+      ]
+    },
+    {
+      "AppName": "app5",
+      "Version": "1",
+      "Format": "Other",
+      "Config": "embedded config"
+    }
+  ]
+}

--- a/cmd/ledgerconfig/sampleconfig/org1-peer0-app1.yaml
+++ b/cmd/ledgerconfig/sampleconfig/org1-peer0-app1.yaml
@@ -1,0 +1,8 @@
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#############################################################
+
+app1config:
+  key1: value1 for org1-peer0-app1
+  key2: value2 for org1-peer0-app1

--- a/cmd/ledgerconfig/sampleconfig/org1-peer0-app2.json
+++ b/cmd/ledgerconfig/sampleconfig/org1-peer0-app2.json
@@ -1,0 +1,4 @@
+{
+  "key1":"value1 for org1-peer0-app2",
+  "key2":"value2 for org1-peer0-app2"
+}

--- a/cmd/ledgerconfig/sampleconfig/org1-peer0-app3.yaml
+++ b/cmd/ledgerconfig/sampleconfig/org1-peer0-app3.yaml
@@ -1,0 +1,8 @@
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#############################################################
+
+app3config:
+  key1: value1 for org1-peer0-app3
+  key2: value2 for org1-peer0-app3

--- a/cmd/ledgerconfig/sampleconfig/org1-peer1-app1.yaml
+++ b/cmd/ledgerconfig/sampleconfig/org1-peer1-app1.yaml
@@ -1,0 +1,8 @@
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#############################################################
+
+app1config:
+  key1: value1 for org1-peer1-app1
+  key2: value2 for org1-peer1-app1

--- a/cmd/ledgerconfig/sampleconfig/org1-peer1-app2.json
+++ b/cmd/ledgerconfig/sampleconfig/org1-peer1-app2.json
@@ -1,0 +1,4 @@
+{
+  "key1":"value1 for org1-peer1-app2",
+  "key2":"value2 for org1-peer1-app2"
+}

--- a/cmd/ledgerconfig/updatecmd/configpreprocessor.go
+++ b/cmd/ledgerconfig/updatecmd/configpreprocessor.go
@@ -1,0 +1,124 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package updatecmd
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/common"
+)
+
+type configPreProcessor struct {
+	configFilePath string
+}
+
+func newConfigPreProcessor(configFilePath string) *configPreProcessor {
+	return &configPreProcessor{configFilePath: configFilePath}
+}
+
+func (cp *configPreProcessor) preProcess(cfg *common.Config) (*common.Config, error) {
+	peers, err := cp.visitPeers(cfg.Peers)
+	if err != nil {
+		return nil, err
+	}
+	apps, err := cp.visitApps(cfg.Apps)
+	if err != nil {
+		return nil, err
+	}
+	return &common.Config{
+		MspID: cfg.MspID,
+		Peers: peers,
+		Apps:  apps,
+	}, nil
+}
+
+func (cp *configPreProcessor) visitPeers(srcPeers []*common.Peer) ([]*common.Peer, error) {
+	peers := make([]*common.Peer, len(srcPeers))
+	for i, p := range srcPeers {
+		apps, err := cp.visitApps(p.Apps)
+		if err != nil {
+			return nil, err
+		}
+		peers[i] = &common.Peer{
+			PeerID: p.PeerID,
+			Apps:   apps,
+		}
+	}
+	return peers, nil
+}
+
+func (cp *configPreProcessor) visitApps(srcApps []*common.App) ([]*common.App, error) {
+	apps := make([]*common.App, len(srcApps))
+	for i, a := range srcApps {
+		var config string
+		var components []*common.Component
+		var err error
+		if a.Config != "" {
+			config, err = cp.visitConfigString(a.Config)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			components, err = cp.visitComponents(a.Components)
+			if err != nil {
+				return nil, err
+			}
+		}
+		apps[i] = &common.App{
+			AppName:    a.AppName,
+			Version:    a.Version,
+			Format:     a.Format,
+			Config:     config,
+			Components: components,
+		}
+	}
+	return apps, nil
+}
+
+func (cp *configPreProcessor) visitComponents(srcComponents []*common.Component) ([]*common.Component, error) {
+	components := make([]*common.Component, len(srcComponents))
+	for i, c := range srcComponents {
+		config, err := cp.visitConfigString(c.Config)
+		if err != nil {
+			return nil, err
+		}
+		components[i] = &common.Component{
+			Name:    c.Name,
+			Version: c.Version,
+			Format:  c.Format,
+			Config:  config,
+		}
+	}
+	return components, nil
+}
+
+func (cp *configPreProcessor) visitConfigString(srcConfig string) (string, error) {
+	// Substitute all of the file refs with the actual contents of the file
+	if !strings.HasPrefix(srcConfig, "file://") {
+		return srcConfig, nil
+	}
+
+	refFilePath := srcConfig[7:]
+	contents, err := cp.readFileRef(refFilePath)
+	if err != nil {
+		return "", errors.Wrapf(err, "error retrieving contents of file [%s]", refFilePath)
+	}
+	return string(contents), nil
+}
+
+func (cp *configPreProcessor) readFileRef(refPath string) ([]byte, error) {
+	var path string
+	if filepath.IsAbs(refPath) || cp.configFilePath == "" {
+		path = refPath
+	} else {
+		// The path is relative to the source config file
+		path = filepath.Join(filepath.Dir(cp.configFilePath), refPath)
+	}
+	return readFile(path)
+}

--- a/cmd/ledgerconfig/updatecmd/filereader.go
+++ b/cmd/ledgerconfig/updatecmd/filereader.go
@@ -1,0 +1,34 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package updatecmd
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+func readFile(path string) ([]byte, error) {
+	file, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return nil, errors.WithMessagef(err, "error opening file [%s]", path)
+	}
+	defer func() {
+		if e := file.Close(); e != nil {
+			// This shouldn't happen
+			panic(err.Error())
+		}
+	}()
+
+	configBytes, err := ioutil.ReadAll(file)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "error reading config file [%s]", path)
+	}
+	return configBytes, nil
+}

--- a/cmd/ledgerconfig/updatecmd/updatecmd.go
+++ b/cmd/ledgerconfig/updatecmd/updatecmd.go
@@ -1,0 +1,271 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package updatecmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hyperledger/fabric-cli/pkg/environment"
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/common"
+)
+
+const (
+	use      = "update"
+	desc     = "Update ledger configuration"
+	longDesc = `
+The update command allows a client to add/update the configuration of one or more applications.
+Configuration can be specified directly on the command-line as a JSON string using the --config option,
+or the path of a configuration file may be specified using the --configfile option. The configuration
+string may be embedded directly in the "Config" element or the Config element may reference a file
+containing the configuration.
+
+The format of the configuration for config with peer is as follows:
+
+{
+  "MspID": "msp.one",
+  "Peers": [
+    {
+      "PeerID": "peer1",
+      "App": [
+        {
+          "AppName": "app1",
+          "Version": "1",
+          "Format":"JSON",
+          "Config": "{\"Key1\":\"value1\",\"Key2\":\"Value2\"}"
+        },
+        {
+          "AppName": "app1",
+          "Version": "2",
+          "Format":"JSON",
+          "Config": "{\"Key1\":\"value1_1\",\"Key2\":\"Value2_1\"}"
+        },
+        {
+          "AppName": "app2",
+          "Version": "1",
+          "Format":"YAML",
+          "Config": "file://path_to_config.yaml"
+        }
+      ]
+    },
+    {
+      "PeerID":"peer2",
+      . . .
+	}
+  ]
+}
+
+The format of the configuration for peer-less config is displayed below:
+{
+  "MspID": "Org1MSP",
+  "Apps": [
+    {
+      "AppName": "app1",
+      "Version": "1",
+      "Format":"Other",
+      "Config": "{config goes here}"
+    },
+    {
+      "AppName": "app2",
+      "Version": "1",
+      "Components": [
+        {
+          "Name": "comp1",
+          "Version": "1"
+          "Format":"Other",
+          "Config": "{comp1 data ver 1}",
+        },
+        {
+          "Name": "comp1",
+          "Version": "2"
+          "Format":"Other",
+          "Config": "{comp1 data ver 2}",
+        },
+        {
+          "Name": "comp2",
+          "Version": "1"
+          "Format":"Other",
+          "Config": "{comp2 data ver 1}",
+        }
+      ]
+    },
+    .....
+  ]
+}
+`
+	examples = `
+- Send the update using a configuration file:
+    $ ./fabric ledgerconfig update --configfile ./sampleconfig/org1-config.json
+
+- Send an update using a configuration string specified in the command-line:
+    $ ./fabric ledgerconfig update --config '{"MspID":"Org1MSP","Peers":[{"PeerID":"peer0.org1.com","App":[{"AppName":"app1","Version":"v1","Format":"Other","Config":"embedded config"}]}]}'
+
+- Send an update using a peer-less configuration string specified in the command-line:
+    $ ./fabric ledgerconfig update --config '{"MspID":"Org1MSP","Apps":[{"AppName":"app1","Version":"v1","Format":"Other","Config":"embedded config"}]}'
+
+- Send an update using a peer-less configuration string specified in the command-line:
+    $ ./fabric ledgerconfig update --config '{"MspID":"general", "Apps": [{"AppName": "publickey", "Version": "v1", "Components": [{"Name":"comp1","Format":"Other","Config":"config1"}] }]}'
+`
+)
+
+const (
+	configFlag  = "config"
+	configUsage = `The config update string in JSON format. Example: --config '{"MspID":"Org1MSP","Peers":[{"PeerID":"peer0.org1.com","App":[{"AppName":"myapp","Version":"1","Format":"JSON",Config":"{\"Org\":\"Org1MSP\",\"Application\":\"app1\"}"}]}]}'`
+
+	configFileFlag  = "configfile"
+	configFileUsage = `The path to the config file. Example: --configfile "./configs/msp1_config.json"`
+
+	noPromptFlag        = "noprompt"
+	noPromptDescription = "If specified then update operation will not prompt for confirmation. Example: --noprompt"
+)
+
+var (
+	errConfigOrConfigFileRequired = "one of --config or --configfile must be specified"
+	errInvalidJSONConfig          = "invalid JSON config"
+	errFileNotFound               = "file not found"
+
+	msgConfigUpdated   = "Configuration successfully updated!"
+	msgAborted         = "Operation aborted"
+	msgContinueOrAbort = "Enter Y to continue or N to abort "
+)
+
+// New returns the ledgerconfig update sub-command
+func New(settings *environment.Settings) *cobra.Command {
+	return newCmd(settings, nil)
+}
+
+func newCmd(settings *environment.Settings, p common.FactoryProvider) *cobra.Command {
+	c := &command{
+		BaseCommand: common.NewBaseCmd(settings, p),
+	}
+	cmd := &cobra.Command{
+		Use:     use,
+		Short:   desc,
+		Long:    longDesc,
+		Example: examples,
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			if err := c.validate(); err != nil {
+				return err
+			}
+			return nil
+		},
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return c.run()
+		},
+	}
+
+	c.Settings = settings
+	cmd.SetOutput(c.Settings.Streams.Out)
+	cmd.SilenceUsage = true
+
+	cmd.Flags().StringVar(&c.config, configFlag, "", configUsage)
+	cmd.Flags().StringVar(&c.configFile, configFileFlag, "", configFileUsage)
+	cmd.Flags().BoolVar(&c.noPrompt, noPromptFlag, false, noPromptDescription)
+
+	return cmd
+}
+
+// command implements the update command
+type command struct {
+	*common.BaseCommand
+
+	// Flags
+	config     string
+	configFile string
+	noPrompt   bool
+}
+
+func (c *command) validate() error {
+	if (c.config == "" && c.configFile == "") || (c.config != "" && c.configFile != "") {
+		return errors.New(errConfigOrConfigFileRequired)
+	}
+	if c.config != "" {
+		return validateConfig(c.config)
+	}
+	return validateConfigFile(c.configFile)
+}
+
+func (c *command) run() error {
+	configBytes, err := c.getConfigBytes()
+	if err != nil {
+		return err
+	}
+
+	cfg := &common.Config{}
+	err = json.Unmarshal(configBytes, cfg)
+	if err != nil {
+		return err
+	}
+
+	// Replace all of the file references with actual config
+	newCfg, err := newConfigPreProcessor(c.configFile).preProcess(cfg)
+	if err != nil {
+		return err
+	}
+
+	configBytes, err = json.Marshal(newCfg)
+	if err != nil {
+		return err
+	}
+
+	// Get confirmation from the user
+	if !c.noPrompt {
+		prompt := fmt.Sprintf("Updating the configuration with:\n\n%s\n\n%s", configBytes, msgContinueOrAbort)
+		if e := c.Fprintln(prompt); e != nil {
+			return e
+		}
+		if strings.ToLower(c.Prompt()) != "y" {
+			return c.Fprintln(msgAborted)
+		}
+	}
+
+	req := channel.Request{
+		ChaincodeID: common.ConfigSCC,
+		Fcn:         "save",
+		Args:        [][]byte{configBytes},
+	}
+
+	ch, err := c.Channel()
+	if err != nil {
+		return err
+	}
+
+	_, err = ch.Execute(req, channel.WithTargetEndpoints(c.Context().Peers...))
+	if err != nil {
+		return err
+	}
+
+	return c.Fprintln(msgConfigUpdated)
+}
+
+func (c *command) getConfigBytes() ([]byte, error) {
+	if c.config != "" {
+		return []byte(c.config), nil
+	}
+	return readFile(c.configFile)
+}
+
+func validateConfig(cfg string) error {
+	config := &common.Config{}
+	if err := json.Unmarshal([]byte(cfg), config); err != nil {
+		return errors.WithMessagef(err, errInvalidJSONConfig)
+	}
+	return nil
+}
+
+func validateConfigFile(file string) error {
+	_, err := os.Stat(file)
+	if os.IsNotExist(err) {
+		return errors.Errorf("%s: [%s]", errFileNotFound, file)
+	}
+	return nil
+}

--- a/cmd/ledgerconfig/updatecmd/updatecmd_test.go
+++ b/cmd/ledgerconfig/updatecmd/updatecmd_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package updatecmd
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/hyperledger/fabric-cli/pkg/environment"
+	"github.com/hyperledger/fabric-cli/pkg/fabric"
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/common"
+	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/mocks"
+)
+
+func TestUpdateCmd_InvalidOptions(t *testing.T) {
+	t.Run("No options", func(t *testing.T) {
+		require.EqualError(t, newMockCmd(t, nil).Execute(), errConfigOrConfigFileRequired)
+	})
+
+	t.Run("--config with --configfile", func(t *testing.T) {
+		require.EqualError(t, newMockCmd(t, nil, "--config", "{}", "--configfile", "./config.json").Execute(), errConfigOrConfigFileRequired)
+	})
+
+	t.Run("Invalid config in --config flag", func(t *testing.T) {
+		err := newMockCmd(t, nil, "--config", "invalid-JSON").Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errInvalidJSONConfig)
+	})
+
+	t.Run("File in --configfile flag not found", func(t *testing.T) {
+		err := newMockCmd(t, nil, "--configfile", "./notthere.json").Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errFileNotFound)
+	})
+}
+
+func TestUpdateCmd_InitializeError(t *testing.T) {
+	t.Run("With channel error", func(t *testing.T) {
+		errExpected := errors.New("channel error")
+		p := func(config *environment.Config) (fabric.Factory, error) { return nil, errExpected }
+		c := newMockCmd(t, p, "--config", `{"MspID":"msp1"}`, "--noprompt")
+		require.EqualError(t, c.Execute(), errExpected.Error())
+	})
+	t.Run("With channel execute error", func(t *testing.T) {
+		factory := &mocks.Factory{}
+		ch := &mocks.Channel{}
+		factory.ChannelReturns(ch, nil)
+
+		errExpected := errors.New("channel execute error")
+		ch.ExecuteReturns(channel.Response{}, errExpected)
+
+		p := func(config *environment.Config) (fabric.Factory, error) { return factory, nil }
+		c := newMockCmd(t, p, "--config", `{"MspID":"msp1"}`, "--noprompt")
+		require.EqualError(t, c.Execute(), errExpected.Error())
+	})
+}
+
+func TestUpdateCmd(t *testing.T) {
+	factory := &mocks.Factory{}
+	c := &mocks.Channel{}
+
+	resp := channel.Response{}
+	c.QueryReturns(resp, nil)
+	factory.ChannelReturns(c, nil)
+
+	p := func(config *environment.Config) (fabric.Factory, error) { return factory, nil }
+
+	t.Run("With --config", func(t *testing.T) {
+		c := newMockCmd(t, p, "--config", `{"MspID":"msp1"}`, "--noprompt")
+		require.NoError(t, c.Execute())
+	})
+
+	t.Run("With --file", func(t *testing.T) {
+		w := &mocks.Writer{}
+		c := newMockCmdWithReaderWriter(t, &mocks.Reader{Bytes: []byte("Y\n")}, w, p, "--configfile", "../sampleconfig/org1-config.json", "--noprompt")
+		require.NoError(t, c.Execute())
+		require.Contains(t, w.Written(), msgConfigUpdated)
+	})
+
+	t.Run("With --file and relative file references - ref file not found", func(t *testing.T) {
+		c := newMockCmd(t, p, "--configfile", "../sampleconfig/invalid-refs-config.json", "--noprompt")
+		err := c.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "../sampleconfig/file-not-there.json: no such file or directory")
+	})
+
+	t.Run("With --file and absolute file references - ref file not found", func(t *testing.T) {
+		c := newMockCmd(t, p, "--configfile", "../sampleconfig/absolute-refs-config.json", "--noprompt")
+		err := c.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "/usr/local/backup/file-not-there.json: no such file or directory")
+	})
+
+	t.Run("With prompt - Y", func(t *testing.T) {
+		w := &mocks.Writer{}
+		c := newMockCmdWithReaderWriter(t, &mocks.Reader{Bytes: []byte("Y\n")}, w, p, "--config", `{"MspID":"msp1"}`)
+		require.NoError(t, c.Execute())
+		require.Contains(t, w.Written(), msgContinueOrAbort)
+		require.Contains(t, w.Written(), msgConfigUpdated)
+	})
+
+	t.Run("With prompt - N", func(t *testing.T) {
+		w := &mocks.Writer{}
+		c := newMockCmdWithReaderWriter(t, &mocks.Reader{Bytes: []byte("N\n")}, w, p, "--config", `{"MspID":"msp1"}`)
+		require.NoError(t, c.Execute())
+		require.Contains(t, w.Written(), msgContinueOrAbort)
+		require.Contains(t, w.Written(), msgAborted)
+		require.NotContains(t, w.Written(), msgConfigUpdated)
+	})
+}
+
+func newMockCmd(t *testing.T, p common.FactoryProvider, args ...string) *cobra.Command {
+	return newMockCmdWithReaderWriter(t, &mocks.Reader{}, &mocks.Writer{}, p, args...)
+}
+
+func newMockCmdWithReaderWriter(t *testing.T, in io.Reader, w io.Writer, p common.FactoryProvider, args ...string) *cobra.Command {
+	settings := environment.NewDefaultSettings()
+	settings.Streams.Out = w
+	settings.Streams.In = in
+
+	settings.Config.CurrentContext = "testctx"
+	settings.Config.Contexts[settings.Config.CurrentContext] = &environment.Context{}
+
+	c := newCmd(settings, p)
+	require.NotNil(t, c)
+
+	c.SetArgs(args)
+
+	return c
+}


### PR DESCRIPTION
Implemented the update sub-command to add/update the configuration of one or more applications.
Configuration can be specified directly on the command-line as a JSON string using the --config option,
or the path of a configuration file may be specified using the --configfile option. The configuration
string may be embedded directly in the "Config" element or the Config element may reference a file
containing the configuration.

closes #3

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>