### PR TITLE
feat: Added ledgerconfig delete sub-command

### DIFF
--- a/cmd/ledgerconfig/common/criteriabasecmd.go
+++ b/cmd/ledgerconfig/common/criteriabasecmd.go
@@ -1,0 +1,138 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"encoding/json"
+
+	"github.com/hyperledger/fabric-cli/pkg/environment"
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+const (
+	criteriaFlag  = "criteria"
+	criteriaUsage = `The search criteria in JSON format. Example: --criteria '{"MspID":"Org1MSP","PeerID":"peer0.org1.com","AppName":"app1","AppVersion":"v1","ComponentName":"comp1","ComponentVersion":"v1"}'`
+
+	mspIDFlag  = "mspid"
+	mspIDUsage = `The ID of the MSP. Example: --mspid Org1MSP`
+
+	peerIDFlag  = "peerid"
+	peerIDUsage = "The ID of the peer to query for. Example: --peerid peer0.org1.com"
+
+	appNameFlag  = "appname"
+	appNameUsage = "The name of the application to query for. Example: --appname app1"
+
+	appVerFlag  = "appver"
+	appVerUsage = "The app version. Example: --appver v1"
+
+	componentNameFlag  = "componentname"
+	componentNameUsage = "The name of the component to query for. Example: --componentname comp1"
+
+	componentVerFlag  = "componentver"
+	componentVerUsage = "The component version. Example: --componentver v1"
+)
+
+var (
+	errMspOrCriteriaRequired = "either --criteria or (at least) --mspid must be specified"
+	errCriteriaMustBeAlone   = "other options cannot be used along with --criteria"
+	errInvalidCriteria       = "invalid criteria"
+)
+
+// CriteriaBaseCommand may be used as a BaseCommand for commands that use search criteria
+type CriteriaBaseCommand struct {
+	*BaseCommand
+
+	// Flags
+	criteriaStr      string
+	mspID            string
+	peerID           string
+	appName          string
+	appVersion       string
+	componentName    string
+	componentVersion string
+}
+
+// NewCriteriaBaseCommand returns a CriteriaBaseCommand
+func NewCriteriaBaseCommand(settings *environment.Settings, p FactoryProvider, cmd *cobra.Command) *CriteriaBaseCommand {
+	c := &CriteriaBaseCommand{
+		BaseCommand: NewBaseCmd(settings, p),
+	}
+
+	c.Settings = settings
+	cmd.SetOutput(c.Settings.Streams.Out)
+	cmd.SilenceUsage = true
+
+	cmd.Flags().StringVar(&c.criteriaStr, criteriaFlag, "", criteriaUsage)
+	cmd.Flags().StringVar(&c.mspID, mspIDFlag, "", mspIDUsage)
+	cmd.Flags().StringVar(&c.peerID, peerIDFlag, "", peerIDUsage)
+	cmd.Flags().StringVar(&c.appName, appNameFlag, "", appNameUsage)
+	cmd.Flags().StringVar(&c.appVersion, appVerFlag, "", appVerUsage)
+	cmd.Flags().StringVar(&c.componentName, componentNameFlag, "", componentNameUsage)
+	cmd.Flags().StringVar(&c.componentVersion, componentVerFlag, "", componentVerUsage)
+
+	return c
+}
+
+// Validate validates the flags
+func (c *CriteriaBaseCommand) Validate() error {
+	if c.criteriaStr != "" {
+		if c.mspID != "" || c.peerID != "" || c.appName != "" || c.appVersion != "" || c.componentName != "" || c.componentVersion != "" {
+			return errors.New(errCriteriaMustBeAlone)
+		}
+
+		// Validate the criteria
+		criteria := &Criteria{}
+		if err := json.Unmarshal([]byte(c.criteriaStr), criteria); err != nil {
+			return errors.WithMessagef(err, errInvalidCriteria)
+		}
+	} else {
+		if c.mspID == "" {
+			return errors.New(errMspOrCriteriaRequired)
+		}
+	}
+	return nil
+}
+
+// GetCriteriaBytes returns the Criteria marshalled as JSON
+func (c *CriteriaBaseCommand) GetCriteriaBytes() ([]byte, error) {
+	if c.criteriaStr != "" {
+		return []byte(c.criteriaStr), nil
+	}
+
+	criteria := &Criteria{
+		MspID:            c.mspID,
+		PeerID:           c.peerID,
+		AppName:          c.appName,
+		AppVersion:       c.appVersion,
+		ComponentName:    c.componentName,
+		ComponentVersion: c.componentVersion,
+	}
+	return json.Marshal(criteria)
+}
+
+// GetConfig returns the config according to the given criteria
+func (c *CriteriaBaseCommand) GetConfig(criteria []byte) ([]byte, error) {
+	req := channel.Request{
+		ChaincodeID: ConfigSCC,
+		Fcn:         "get",
+		Args:        [][]byte{criteria},
+	}
+
+	ch, err := c.Channel()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := ch.Query(req, channel.WithTargetEndpoints(c.Context().Peers...))
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Payload, nil
+}

--- a/cmd/ledgerconfig/common/criteriabasecmd_test.go
+++ b/cmd/ledgerconfig/common/criteriabasecmd_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hyperledger/fabric-cli/pkg/environment"
+	"github.com/hyperledger/fabric-cli/pkg/fabric"
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/mocks"
+)
+
+func TestCriteriaBaseCommand(t *testing.T) {
+	t.Run("No options", func(t *testing.T) {
+		require.EqualError(t, newMockCriteriaCmd(t, &testCmd{}, nil).Execute(), errMspOrCriteriaRequired)
+	})
+
+	t.Run("--mspid with --criteria", func(t *testing.T) {
+		require.EqualError(t, newMockCriteriaCmd(t, &testCmd{}, nil, "--mspid", "MSP1", "--criteria", "{}").Execute(), errCriteriaMustBeAlone)
+	})
+
+	t.Run("--peerid with --criteria", func(t *testing.T) {
+		require.EqualError(t, newMockCriteriaCmd(t, &testCmd{}, nil, "--peerid", "peer1", "--criteria", "{}").Execute(), errCriteriaMustBeAlone)
+	})
+
+	t.Run("--appname with --criteria", func(t *testing.T) {
+		require.EqualError(t, newMockCriteriaCmd(t, &testCmd{}, nil, "--appname", "app1", "--criteria", "{}").Execute(), errCriteriaMustBeAlone)
+	})
+
+	t.Run("--appver with --criteria", func(t *testing.T) {
+		require.EqualError(t, newMockCriteriaCmd(t, &testCmd{}, nil, "--appver", "v1", "--criteria", "{}").Execute(), errCriteriaMustBeAlone)
+	})
+
+	t.Run("--componentname with --criteria", func(t *testing.T) {
+		require.EqualError(t, newMockCriteriaCmd(t, &testCmd{}, nil, "--componentname", "comp1", "--criteria", "{}").Execute(), errCriteriaMustBeAlone)
+	})
+
+	t.Run("--componentver with --criteria", func(t *testing.T) {
+		require.EqualError(t, newMockCriteriaCmd(t, &testCmd{}, nil, "--componentver", "v1", "--criteria", "{}").Execute(), errCriteriaMustBeAlone)
+	})
+
+	t.Run("Invalid --criteria", func(t *testing.T) {
+		c := newMockCriteriaCmd(t, &testCmd{}, nil, "--criteria", "xxx")
+		err := c.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errInvalidCriteria)
+	})
+
+	t.Run("GetCriteriaBytes with --criteria => valid", func(t *testing.T) {
+		const expectedBytes = `{"MspID":"MSP1","PeerID":"peer1","AppName":"app1","AppVersion":"v1","ComponentName":"comp1","ComponentVersion":"v1"}`
+		mc := &testCmd{}
+		c := newMockCriteriaCmd(t, mc, nil, "--criteria", expectedBytes)
+		err := c.Execute()
+		require.NoError(t, err)
+
+		bytes, err := mc.GetCriteriaBytes()
+		require.NoError(t, err)
+		require.Equal(t, expectedBytes, string(bytes))
+	})
+
+	t.Run("GetCriteriaBytes with flags => valid", func(t *testing.T) {
+		const msp = "MSP1"
+		const peer = "peer1"
+		const app = "app1"
+		const version = "v1"
+		const comp = "comp1"
+
+		expectedBytes := fmt.Sprintf(`{"MspID":"%s","PeerID":"%s","AppName":"%s","AppVersion":"%s","ComponentName":"%s","ComponentVersion":"%s"}`, msp, peer, app, version, comp, version)
+		mc := &testCmd{}
+		c := newMockCriteriaCmd(t, mc, nil, "--mspid", msp, "--peerid", peer, "--appname", app, "--appver", version, "--componentname", comp, "--componentver", version)
+		err := c.Execute()
+		require.NoError(t, err)
+
+		bytes, err := mc.GetCriteriaBytes()
+		require.NoError(t, err)
+		require.Equal(t, expectedBytes, string(bytes))
+	})
+}
+
+func TestCriteriaBaseCommand_GetConfig(t *testing.T) {
+	factory := &mocks.Factory{}
+	p := func(config *environment.Config) (fabric.Factory, error) { return factory, nil }
+
+	t.Run("GetConfig => valid", func(t *testing.T) {
+		const payload = `[{"MspID":"msp1"}]`
+		ch := &mocks.Channel{}
+		resp := channel.Response{Payload: []byte(payload)}
+		ch.QueryReturns(resp, nil)
+		factory.ChannelReturns(ch, nil)
+
+		mc := &testCmd{}
+		c := newMockCriteriaCmd(t, mc, p)
+		require.NotNil(t, c)
+		bytes, err := mc.GetConfig([]byte(`["MspID":"msp1"}`))
+		require.NoError(t, err)
+		require.Equal(t, payload, string(bytes))
+	})
+
+	t.Run("GetConfig => channel error", func(t *testing.T) {
+		errExpected := errors.New("channel error")
+		factory.ChannelReturns(nil, errExpected)
+
+		mc := &testCmd{}
+		c := newMockCriteriaCmd(t, mc, p)
+		require.NotNil(t, c)
+		_, err := mc.GetConfig([]byte(`["MspID":"msp1"}`))
+		require.EqualError(t, err, errExpected.Error())
+	})
+
+	t.Run("GetConfig => query error", func(t *testing.T) {
+		errExpected := errors.New("query error")
+		ch := &mocks.Channel{}
+		ch.QueryReturns(channel.Response{}, errExpected)
+		factory.ChannelReturns(ch, nil)
+
+		mc := &testCmd{}
+		c := newMockCriteriaCmd(t, mc, p)
+		require.NotNil(t, c)
+		_, err := mc.GetConfig([]byte(`["MspID":"msp1"}`))
+		require.EqualError(t, err, errExpected.Error())
+	})
+}
+
+type testCmd struct {
+	*CriteriaBaseCommand
+}
+
+func newMockCriteriaCmd(t *testing.T, c *testCmd, p FactoryProvider, args ...string) *cobra.Command {
+	cmd := &cobra.Command{
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.Validate()
+		},
+	}
+	c.CriteriaBaseCommand = newMockCriteriaBaseCmd(t, cmd, p, args...)
+	return cmd
+}
+
+func newMockCriteriaBaseCmd(t *testing.T, cmd *cobra.Command, p FactoryProvider, args ...string) *CriteriaBaseCommand {
+	settings := environment.NewDefaultSettings()
+	settings.Streams.In = &mocks.Reader{}
+	settings.Streams.Out = &mocks.Writer{}
+
+	settings.Config.CurrentContext = "testctx"
+	settings.Config.Contexts[settings.Config.CurrentContext] = &environment.Context{}
+
+	cmd.SetArgs(args)
+
+	c := NewCriteriaBaseCommand(settings, p, cmd)
+	require.NotNil(t, c)
+
+	return c
+}

--- a/cmd/ledgerconfig/deletecmd/deletecmd.go
+++ b/cmd/ledgerconfig/deletecmd/deletecmd.go
@@ -1,0 +1,137 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package deletecmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hyperledger/fabric-cli/pkg/environment"
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
+	"github.com/spf13/cobra"
+	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/common"
+)
+
+const (
+	use      = "delete"
+	desc     = "Delete ledger configuration"
+	longDesc = `
+The delete command allows the client to delete the MSP's configuration using search criteria. The criteria consists of:
+
+* MspID (mandatory)           - The MSP ID of the organization
+* PeerID (optional)           - The ID of the peer
+* AppName (optional)          - The application name
+* AppVersion (optional)       - The application version
+* ComponentName (optional)    - The component name
+* ComponentVersion (optional) - The component version
+
+Criteria may be specified as a JSON string (using the --criteria option) or it may be specified using the options:
+	--mspid, --peerid, --appname, --appver, --componentname and --componentver
+
+If PeerID and AppName are not specified then all of the MSP's configuration is deleted.
+`
+	examples = `
+- Delete an application's configuration for a given peer:
+    $ ./fabric ledgerconfig delete --mspid Org1MSP --peerid peer0.org1.com --appname myapp --appver 1
+
+- Delete a specific version of a component's configuration':
+    $ ./fabric ledgerconfig delete --mspid Org1MSP --appname myapp --appver 1 --componentname comp1 --componentver 1
+
+- Delete all configuration in Org1MSP:
+    $ ./fabric ledgerconfig delete --mspid Org1MSP
+`
+)
+
+const (
+	noPromptFlag        = "noprompt"
+	noPromptDescription = "If specified then delete operation will not prompt for confirmation. Example: --noprompt"
+
+	msgConfigDeleted   = "Configuration successfully deleted!"
+	msgAborted         = "Operation aborted"
+	msgContinueOrAbort = "Enter Y to continue or N to abort "
+	msgNoConfig        = "No configuration matches the given criteria"
+)
+
+// New creates a new delete command
+func New(settings *environment.Settings) *cobra.Command {
+	return newCmd(settings, nil)
+}
+
+func newCmd(settings *environment.Settings, p common.FactoryProvider) *cobra.Command {
+	c := &command{}
+
+	cmd := &cobra.Command{
+		Use:     use,
+		Short:   desc,
+		Long:    longDesc,
+		Example: examples,
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			return c.Validate()
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return c.run()
+		},
+	}
+	c.CriteriaBaseCommand = common.NewCriteriaBaseCommand(settings, p, cmd)
+
+	cmd.Flags().BoolVar(&c.noPrompt, noPromptFlag, false, noPromptDescription)
+
+	return cmd
+}
+
+// command implements the delete command
+type command struct {
+	*common.CriteriaBaseCommand
+
+	// Flags
+	noPrompt bool
+}
+
+func (c *command) run() error {
+	criteriaBytes, err := c.GetCriteriaBytes()
+	if err != nil {
+		return err
+	}
+
+	req := channel.Request{
+		ChaincodeID: common.ConfigSCC,
+		Fcn:         "delete",
+		Args:        [][]byte{criteriaBytes},
+	}
+
+	// Get confirmation from the user
+	if !c.noPrompt {
+		// Display to the user the configuration that will be deleted
+		config, e := c.GetConfig(criteriaBytes)
+		if e != nil {
+			return e
+		}
+		if string(config) == "null" {
+			return c.Fprintln(msgNoConfig)
+		}
+		prompt := fmt.Sprintf("The following configuration will be deleted:\n\n%s\n\n%s", config, msgContinueOrAbort)
+		e = c.Fprintln(prompt)
+		if e != nil {
+			return e
+		}
+		if strings.ToLower(c.Prompt()) != "y" {
+			return c.Fprintln(msgAborted)
+		}
+	}
+
+	ch, err := c.Channel()
+	if err != nil {
+		return err
+	}
+
+	_, err = ch.Execute(req, channel.WithTargetEndpoints(c.Context().Peers...))
+	if err != nil {
+		return err
+	}
+
+	return c.Fprintln(msgConfigDeleted)
+}

--- a/cmd/ledgerconfig/deletecmd/deletecmd_test.go
+++ b/cmd/ledgerconfig/deletecmd/deletecmd_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package deletecmd
+
+import (
+	"io"
+	"testing"
+
+	"github.com/hyperledger/fabric-cli/pkg/environment"
+	"github.com/hyperledger/fabric-cli/pkg/fabric"
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/common"
+	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/mocks"
+)
+
+func TestQueryCmd_InitializeError(t *testing.T) {
+	t.Run("With channel error", func(t *testing.T) {
+		errExpected := errors.New("channel error")
+		p := func(config *environment.Config) (fabric.Factory, error) { return nil, errExpected }
+		c := newMockCmd(t, p, "--criteria", `{"MspID":"msp1"}`, "--noprompt")
+		require.EqualError(t, c.Execute(), errExpected.Error())
+	})
+	t.Run("With channel execute error", func(t *testing.T) {
+		factory := &mocks.Factory{}
+		ch := &mocks.Channel{}
+		factory.ChannelReturns(ch, nil)
+
+		errExpected := errors.New("channel execute error")
+		ch.ExecuteReturns(channel.Response{}, errExpected)
+
+		p := func(config *environment.Config) (fabric.Factory, error) { return factory, nil }
+		c := newMockCmd(t, p, "--criteria", `{"MspID":"msp1"}`, "--noprompt")
+		require.EqualError(t, c.Execute(), errExpected.Error())
+	})
+}
+
+func TestDeleteCmd(t *testing.T) {
+	factory := &mocks.Factory{}
+	c := &mocks.Channel{}
+	factory.ChannelReturns(c, nil)
+	p := func(config *environment.Config) (fabric.Factory, error) { return factory, nil }
+
+	t.Run("With --criteria", func(t *testing.T) {
+		w := &mocks.Writer{}
+		c := newMockCmdWithReaderWriter(t, &mocks.Reader{}, w, p, "--criteria", `{"MspID":"msp1"}`, "--noprompt")
+		require.NoError(t, c.Execute())
+		require.NotContains(t, w.Written(), msgContinueOrAbort) // Confirmation prompt should not be displayed
+	})
+	t.Run("With --mspid", func(t *testing.T) {
+		w := &mocks.Writer{}
+		c := newMockCmdWithReaderWriter(t, &mocks.Reader{}, w, p, "--mspid", "msp1", "--noprompt")
+		require.NoError(t, c.Execute())
+		require.NotContains(t, w.Written(), msgContinueOrAbort) // Confirmation prompt should not be displayed
+	})
+	t.Run("With prompt - Y", func(t *testing.T) {
+		const payload = `[{"MspID":"msp1","PeerID":"","AppName":"app3","AppVersion":"1","TxID":"tx1","Format":"Other","Config":"config"}]`
+		c.QueryReturns(channel.Response{Payload: []byte(payload)}, nil)
+		w := &mocks.Writer{}
+		c := newMockCmdWithReaderWriter(t, &mocks.Reader{Bytes: []byte("Y\n")}, w, p, "--criteria", `{"MspID":"msp1"}`)
+		require.NoError(t, c.Execute())
+		require.Contains(t, w.Written(), payload)            // The configuration to be deleted should be displayed
+		require.Contains(t, w.Written(), msgContinueOrAbort) // The Y|N prompt should be displayed
+		require.Contains(t, w.Written(), msgConfigDeleted)   // The message saying that the delete was successful should be displayed
+	})
+	t.Run("With prompt - N", func(t *testing.T) {
+		const payload = `[{"MspID":"msp1","PeerID":"","AppName":"app3","AppVersion":"1","TxID":"tx1","Format":"Other","Config":"config"}]`
+		c.QueryReturns(channel.Response{Payload: []byte(payload)}, nil)
+		w := &mocks.Writer{}
+		c := newMockCmdWithReaderWriter(t, &mocks.Reader{Bytes: []byte("N\n")}, w, p, "--criteria", `{"MspID":"msp1"}`)
+		require.NoError(t, c.Execute())
+		require.Contains(t, w.Written(), payload)             // The configuration to be deleted should be displayed
+		require.Contains(t, w.Written(), msgContinueOrAbort)  // The Y|N prompt should be displayed
+		require.Contains(t, w.Written(), msgAborted)          // The message saying that the delete was aborted should be displayed
+		require.NotContains(t, w.Written(), msgConfigDeleted) // The message saying that the delete was successful should NOT be displayed
+	})
+	t.Run("With prompt - No config for criteria", func(t *testing.T) {
+		c.QueryReturns(channel.Response{Payload: []byte("null")}, nil)
+		w := &mocks.Writer{}
+		c := newMockCmdWithReaderWriter(t, &mocks.Reader{Bytes: []byte("Y\n")}, w, p, "--mspid", "msp1")
+		require.NoError(t, c.Execute())
+		require.Equal(t, msgNoConfig, w.Written())
+	})
+	t.Run("With prompt - query error", func(t *testing.T) {
+		errExpected := errors.New("query error")
+		c.QueryReturns(channel.Response{}, errExpected)
+		w := &mocks.Writer{}
+		c := newMockCmdWithReaderWriter(t, &mocks.Reader{Bytes: []byte("Y\n")}, w, p, "--criteria", `{"MspID":"msp1"}`)
+		require.EqualError(t, c.Execute(), errExpected.Error())
+	})
+}
+
+func newMockCmd(t *testing.T, p common.FactoryProvider, args ...string) *cobra.Command {
+	return newMockCmdWithReaderWriter(t, &mocks.Reader{}, &mocks.Writer{}, p, args...)
+}
+
+func newMockCmdWithReaderWriter(t *testing.T, in io.Reader, w io.Writer, p common.FactoryProvider, args ...string) *cobra.Command {
+	settings := environment.NewDefaultSettings()
+	settings.Streams.Out = w
+	settings.Streams.In = in
+
+	settings.Config.CurrentContext = "testctx"
+	settings.Config.Contexts[settings.Config.CurrentContext] = &environment.Context{}
+
+	c := newCmd(settings, p)
+	require.NotNil(t, c)
+
+	c.SetArgs(args)
+
+	return c
+}

--- a/cmd/ledgerconfig/ledgerconfig.go
+++ b/cmd/ledgerconfig/ledgerconfig.go
@@ -9,6 +9,7 @@ package main
 import (
 	"github.com/hyperledger/fabric-cli/pkg/environment"
 	"github.com/spf13/cobra"
+	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/deletecmd"
 	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/querycmd"
 	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/updatecmd"
 )
@@ -32,6 +33,7 @@ func New(settings *environment.Settings) *cobra.Command {
 	cmd.AddCommand(
 		querycmd.New(settings),
 		updatecmd.New(settings),
+		deletecmd.New(settings),
 	)
 	return cmd
 }

--- a/cmd/ledgerconfig/ledgerconfig_test.go
+++ b/cmd/ledgerconfig/ledgerconfig_test.go
@@ -30,4 +30,6 @@ func TestNew(t *testing.T) {
 	require.Contains(t, w.Written(), "Query ledger configuration")
 	// Make sure that the update command was added
 	require.Contains(t, w.Written(), "Update ledger configuration")
+	// Make sure that the delete command was added
+	require.Contains(t, w.Written(), "Delete ledger configuration")
 }

--- a/cmd/ledgerconfig/querycmd/querycmd_test.go
+++ b/cmd/ledgerconfig/querycmd/querycmd_test.go
@@ -20,43 +20,6 @@ import (
 	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/mocks"
 )
 
-func TestQueryCmd_InvalidOptions(t *testing.T) {
-	t.Run("No options", func(t *testing.T) {
-		require.EqualError(t, newMockCmd(t, &mocks.Writer{}, nil).Execute(), errMspOrCriteriaRequired)
-	})
-
-	t.Run("--mspid with --criteria", func(t *testing.T) {
-		require.EqualError(t, newMockCmd(t, &mocks.Writer{}, nil, "--mspid", "MSP1", "--criteria", "{}").Execute(), errCriteriaMustBeAlone)
-	})
-
-	t.Run("--peerid with --criteria", func(t *testing.T) {
-		require.EqualError(t, newMockCmd(t, &mocks.Writer{}, nil, "--peerid", "peer1", "--criteria", "{}").Execute(), errCriteriaMustBeAlone)
-	})
-
-	t.Run("--appname with --criteria", func(t *testing.T) {
-		require.EqualError(t, newMockCmd(t, &mocks.Writer{}, nil, "--appname", "app1", "--criteria", "{}").Execute(), errCriteriaMustBeAlone)
-	})
-
-	t.Run("--appver with --criteria", func(t *testing.T) {
-		require.EqualError(t, newMockCmd(t, &mocks.Writer{}, nil, "--appver", "v1", "--criteria", "{}").Execute(), errCriteriaMustBeAlone)
-	})
-
-	t.Run("--componentname with --criteria", func(t *testing.T) {
-		require.EqualError(t, newMockCmd(t, &mocks.Writer{}, nil, "--componentname", "comp1", "--criteria", "{}").Execute(), errCriteriaMustBeAlone)
-	})
-
-	t.Run("--componentver with --criteria", func(t *testing.T) {
-		require.EqualError(t, newMockCmd(t, &mocks.Writer{}, nil, "--componentver", "v1", "--criteria", "{}").Execute(), errCriteriaMustBeAlone)
-	})
-
-	t.Run("Invalid --criteria", func(t *testing.T) {
-		c := newMockCmd(t, &mocks.Writer{}, nil, "--criteria", "xxx")
-		err := c.Execute()
-		require.Error(t, err)
-		require.Contains(t, err.Error(), errInvalidCriteria)
-	})
-}
-
 func TestQueryCmd_InitializeError(t *testing.T) {
 	t.Run("With channel error", func(t *testing.T) {
 		errExpected := errors.New("channel error")


### PR DESCRIPTION
Implemented the delete sub-command to delete the MSP's configuration using search criteria. The criteria consists of:

- MspID: The MSP ID of the organization
- PeerID: The ID of the peer
- AppName: The application name
- AppVersion: The application version
- ComponentName: The component name
- ComponentVersion: The component version

Criteria may be specified as a JSON string (using the --criteria option) or it may be specified using the options:
	--mspid, --peerid, --appname, --appver, --componentname and --componentver

If PeerID and AppName are not specified then all of the MSP's configuration is deleted.

closes #4

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>