### PR TITLE
feat: Display formatted JSON

### DIFF
--- a/cmd/ledgerconfig/common/formatter.go
+++ b/cmd/ledgerconfig/common/formatter.go
@@ -1,0 +1,22 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// FormatJSON transforms the given JSON into a displayable format
+func FormatJSON(jsonBytes []byte) ([]byte, error) {
+	var buff bytes.Buffer
+	err := json.Indent(&buff, jsonBytes, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return buff.Bytes(), nil
+}

--- a/cmd/ledgerconfig/common/formatter_test.go
+++ b/cmd/ledgerconfig/common/formatter_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	jsonStr = `{"MspID":"Org1MSP","Apps":[{"AppName":"app1","Version":"1"}]}`
+
+	formattedJSONStr = `{
+  "MspID": "Org1MSP",
+  "Apps": [
+    {
+      "AppName": "app1",
+      "Version": "1"
+    }
+  ]
+}`
+)
+
+func TestFormatJSON(t *testing.T) {
+	formatted, err := FormatJSON([]byte(jsonStr))
+	require.NoError(t, err)
+	require.Equal(t, formattedJSONStr, string(formatted))
+}

--- a/cmd/ledgerconfig/deletecmd/deletecmd.go
+++ b/cmd/ledgerconfig/deletecmd/deletecmd.go
@@ -113,12 +113,11 @@ func (c *command) run() error {
 		if string(config) == "null" {
 			return c.Fprintln(msgNoConfig)
 		}
-		prompt := fmt.Sprintf("The following configuration will be deleted:\n\n%s\n\n%s", config, msgContinueOrAbort)
-		e = c.Fprintln(prompt)
+		confirmed, e := c.confirmDelete(config)
 		if e != nil {
 			return e
 		}
-		if strings.ToLower(c.Prompt()) != "y" {
+		if !confirmed {
 			return c.Fprintln(msgAborted)
 		}
 	}
@@ -134,4 +133,18 @@ func (c *command) run() error {
 	}
 
 	return c.Fprintln(msgConfigDeleted)
+}
+
+// confirmDelete prompts the user for confirmation of the delete
+func (c *command) confirmDelete(config []byte) (bool, error) {
+	displayedJSON, err := common.FormatJSON(config)
+	if err != nil {
+		return false, err
+	}
+	prompt := fmt.Sprintf("The following configuration will be deleted:\n\n%s\n\n%s", displayedJSON, msgContinueOrAbort)
+	err = c.Fprintln(prompt)
+	if err != nil {
+		return false, err
+	}
+	return strings.ToLower(c.Prompt()) == "y", nil
 }

--- a/cmd/ledgerconfig/updatecmd/updatecmd_test.go
+++ b/cmd/ledgerconfig/updatecmd/updatecmd_test.go
@@ -115,6 +115,13 @@ func TestUpdateCmd(t *testing.T) {
 		require.Contains(t, w.Written(), msgAborted)
 		require.NotContains(t, w.Written(), msgConfigUpdated)
 	})
+
+	t.Run("With prompt - output stream error", func(t *testing.T) {
+		errExpected := errors.New("output stream error")
+		w := &mocks.Writer{Err: errExpected}
+		c := newMockCmdWithReaderWriter(t, &mocks.Reader{Bytes: []byte("N\n")}, w, p, "--config", `{"MspID":"msp1"}`)
+		require.EqualError(t, c.Execute(), errExpected.Error())
+	})
 }
 
 func newMockCmd(t *testing.T, p common.FactoryProvider, args ...string) *cobra.Command {


### PR DESCRIPTION
- Added the flag, --format, to the query sub-command to format the retrieved JSON configuration
- Formatted the JSON in the confirmation prompt of the update sub-command
- In the delete sub-command, retrieve the config that matches the given criteria and display the formatted JSON to the user in the confirmation prompt

closes #9

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>