### PR TITLE
chore: Build fabric-cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
 # Supported Targets:
 #
 # all:                        runs checks, unit tests, and builds the plugins
+# plugins:                    builds fabric-cli and plugins
 # unit-test:                  runs unit tests
 # lint:                       runs linters
 # checks:                     runs code checks
@@ -17,6 +18,7 @@
 # Local variables used by makefile
 PROJECT_NAME            = fabric-cli-ext
 export GO111MODULE      = on
+export FABRIC_CLI_VERSION ?= f6d60d55e800403c587b564c1ca383b2cb496bed
 
 checks: version license lint
 
@@ -26,7 +28,7 @@ lint:
 license: version
 	@scripts/check_license.sh
 
-all: clean checks plugins unit-test
+all: clean checks unit-test plugins
 
 unit-test:
 	@scripts/unit.sh

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ make checks
 
 # run unit-test
 make unit-test
+
+# build fabric-cli and plugins
+make plugins
+
+# install and run ledgerconfig plugin
+cd .build/
+bin/fabric plugin install ./ledgerconfig
+bin/fabric ledgerconfig
 ```
 
 ## Build dependencies

--- a/scripts/build_plugins.sh
+++ b/scripts/build_plugins.sh
@@ -7,8 +7,33 @@
 
 set -e
 
+echo "Building fabric-cli..."
+
+mkdir -p .build/bin
+cd .build
+rm -rf fabric-cli
+git clone https://github.com/hyperledger/fabric-cli.git
+cd fabric-cli
+git checkout $FABRIC_CLI_VERSION
+make
+cp ./bin/fabric ../bin/fabric
+cd ../
+
 echo "Building plugins..."
 
+# The plugin needs to import exactly the same source code as was used to build fabric-cli, otherwise
+# an error will result when the plugin is loaded. So, copy fabric-cli-ext and modify go.mod to
+# replace github/hyperledger/fabric-cli with the local copy.
+mkdir ./fabric-cli-ext
+cp -r ../cmd/ ./fabric-cli-ext/cmd/
+cp ../go.mod ./fabric-cli-ext/
+cd ./fabric-cli-ext
+sed  -e "\$areplace github.com/hyperledger/fabric-cli => ..\/fabric-cli" -i go.mod
+
 # ledgerconfig
-go build -buildmode=plugin -o ./.build/ledgerconfig/ledgerconfig.so ./cmd/ledgerconfig/ledgerconfig.go
-cp ./cmd/ledgerconfig/plugin.yaml ./.build/ledgerconfig/
+go build -buildmode=plugin -o ../ledgerconfig/ledgerconfig.so ./cmd/ledgerconfig/ledgerconfig.go
+cp ./cmd/ledgerconfig/plugin.yaml ../ledgerconfig/
+
+cd ..
+rm -rf ./fabric-cli
+rm -rf ./fabric-cli-ext


### PR DESCRIPTION
Updated build_plugins.sh to first build fabric-cli and then build the plugins. The plugin build needs to point to exactly the same source code as the fabric-cli build, otherwise an error will result when the plugin is loaded.

closes #11

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>