### PR TITLE
feat: Added 'file upload' command

### DIFF
--- a/cmd/file/file.go
+++ b/cmd/file/file.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hyperledger/fabric-cli/pkg/environment"
 
 	"github.com/trustbloc/fabric-cli-ext/cmd/file/createidxcmd"
+	"github.com/trustbloc/fabric-cli-ext/cmd/file/uploadcmd"
 )
 
 const (
@@ -33,6 +34,7 @@ func New(settings *environment.Settings) *cobra.Command {
 
 	cmd.AddCommand(
 		createidxcmd.New(settings),
+		uploadcmd.New(settings),
 	)
 
 	return cmd

--- a/cmd/file/uploadcmd/model.go
+++ b/cmd/file/uploadcmd/model.go
@@ -1,0 +1,49 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package uploadcmd
+
+import (
+	"encoding/json"
+)
+
+type uploadFile struct {
+	ContentType string `json:"contentType"`
+	Content     []byte `json:"content"`
+}
+
+type fileInfo struct {
+	Name        string `json:",omitempty"`
+	ID          string `json:",omitempty"`
+	ContentType string `json:",omitempty"`
+	Content     []byte `json:",omitempty"`
+}
+
+type jsonPatch struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value string `json:"value"`
+}
+
+type files []*fileInfo
+
+func (f files) String() string {
+	ff := make([]*fileInfo, len(f))
+	for i, info := range f {
+		ff[i] = &fileInfo{
+			Name:        info.Name,
+			ID:          info.ID,
+			ContentType: info.ContentType,
+		}
+	}
+
+	bytes, err := json.Marshal(ff)
+	if err != nil {
+		panic(err)
+	}
+
+	return string(bytes)
+}

--- a/cmd/file/uploadcmd/testdata/person.schema.json
+++ b/cmd/file/uploadcmd/testdata/person.schema.json
@@ -1,0 +1,21 @@
+{
+  "$id": "https://example.com/person.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "type": "string",
+      "description": "The person's first name."
+    },
+    "lastName": {
+      "type": "string",
+      "description": "The person's last name."
+    },
+    "age": {
+      "description": "Age in years which must be equal to or greater than zero.",
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+}

--- a/cmd/file/uploadcmd/uploadcmd.go
+++ b/cmd/file/uploadcmd/uploadcmd.go
@@ -1,0 +1,432 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package uploadcmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"mime"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/hyperledger/fabric-cli/pkg/environment"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/document"
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/helper"
+
+	"github.com/trustbloc/fabric-cli-ext/cmd/basecmd"
+	"github.com/trustbloc/fabric-cli-ext/cmd/file/httpclient"
+)
+
+const (
+	use      = "upload"
+	desc     = "Upload a file to DCAS"
+	longDesc = `
+The upload command allows a client to upload one or more files to DCAS and add them to a Sidetree file index document. The response is a JSON document that contains the names of the files that were updated along with their DCAS ID and content-type.
+`
+	examples = `
+- Upload two files to the '/content' path and add index entries to the given file index document:
+    $ ./fabric file upload --url http://localhost:48326/content --files ./fixtures/testdata/v1/person.schema.json;./fixtures/testdata/v1/raised-hand.png --idxurl http://localhost:48326/file/file:idx:EiAuN66iEpuRt6IIu-2sO3bRM74sS_AIuY6jTbtFUsqAaA== --pwd pwd1 --nextpwd pwd2 --noprompt
+
+	Response:
+		[
+		  {
+			"Name": "person.schema.json",
+			"ID": "TbVyraOqG00TacPQH5WwWGnxkszpYSEhBKRyX_f25JI=",
+			"ContentType": "application/json"
+		  },
+		  {
+			"Name": "raised-hand.png",
+			"ID": "k1fqlkDdtmkTBVTHQgvpJbhTEch2XP0cn0C-DuP-9pE=",
+			"ContentType": "image/png"
+		  }
+		]
+`
+)
+
+const (
+	fileFlag  = "files"
+	fileUsage = "The semi-colin separated paths of the files to upload. Example: --files ./samples/content1.json;./samples/image.png"
+
+	urlFlag  = "url"
+	urlUsage = "The URL to which to add the file(s). Example: --url http://localhost:48326/content"
+
+	fileIndexURLFlag  = "idxurl"
+	fileIndexURLUsage = "The URL of the file index Sidetree document to be updated with the new/updated files. Example: --idxurl http://localhost:48326/file/file:idx:1234"
+
+	fileIndexUpdateOTPFlag  = "pwd"
+	fileIndexUpdateOTPUsage = "The one time password required to update the file index Sidetree document. Example: --pwd pwd1"
+
+	fileIndexNextUpdateOTPFlag  = "nextpwd"
+	fileIndexNextUpdateOTPUsage = "The one time password required for the next update of the file index Sidetree document. Example: --nextpwd pwd2"
+
+	noPromptFlag  = "noprompt"
+	noPromptUsage = "If specified then the upload operation will not prompt for confirmation. Example: --noprompt"
+
+	msgAborted         = "Operation aborted"
+	msgContinueOrAbort = "Enter Y to continue or N to abort "
+
+	sha2_256 = 18
+)
+
+var (
+	errURLRequired                    = errors.New("URL (--url) is required")
+	errFilesRequired                  = errors.New("files (--files) is required")
+	errFileIndexURLRequired           = errors.New("file index URL (--idxurl) is required")
+	errFileIndexUpdateOTPRequired     = errors.New("password (--pwd) required")
+	errFileIndexNextUpdateOTPRequired = errors.New("next update password (--nextpwd) required")
+	errNoFileExtension                = errors.New("content type cannot be deduced since no file extension provided")
+	errUnknownExtension               = errors.New("content type cannot be deduced from extension")
+)
+
+type httpClient interface {
+	Post(url string, req []byte) (*httpclient.HTTPResponse, error)
+	Get(url string) (*httpclient.HTTPResponse, error)
+}
+
+// New returns the file upload sub-command
+func New(settings *environment.Settings) *cobra.Command {
+	return newCmd(settings, httpclient.New())
+}
+
+func newCmd(settings *environment.Settings, client httpClient) *cobra.Command {
+	c := &command{
+		Command: basecmd.New(settings, nil),
+		client:  client,
+	}
+
+	cmd := &cobra.Command{
+		Use:     use,
+		Short:   desc,
+		Long:    longDesc,
+		Example: examples,
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			if err := c.validateAndProcessArgs(); err != nil {
+				return err
+			}
+			return nil
+		},
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return c.run()
+		},
+	}
+
+	c.Settings = settings
+	cmd.SetOutput(c.Settings.Streams.Out)
+	cmd.SilenceUsage = true
+
+	cmd.Flags().StringVar(&c.file, fileFlag, "", fileUsage)
+	cmd.Flags().StringVar(&c.url, urlFlag, "", urlUsage)
+	cmd.Flags().StringVar(&c.fileIndexURL, fileIndexURLFlag, "", fileIndexURLUsage)
+	cmd.Flags().StringVar(&c.fileIndexUpdateOTP, fileIndexUpdateOTPFlag, "", fileIndexUpdateOTPUsage)
+	cmd.Flags().StringVar(&c.fileIndexNextUpdateOTP, fileIndexNextUpdateOTPFlag, "", fileIndexNextUpdateOTPUsage)
+	cmd.Flags().BoolVar(&c.noPrompt, noPromptFlag, false, noPromptUsage)
+
+	return cmd
+}
+
+// command implements the update command
+type command struct {
+	*basecmd.Command
+	client httpClient
+
+	file                   string
+	url                    string
+	basePath               string
+	fileIndexURL           string
+	fileIndexBaseURL       string
+	fileIndexUpdateOTP     string
+	fileIndexNextUpdateOTP string
+	noPrompt               bool
+}
+
+func (c *command) validateAndProcessArgs() error {
+	if c.url == "" {
+		return errURLRequired
+	}
+
+	pos := strings.LastIndex(c.url, "/")
+	if pos == -1 {
+		return errors.New("invalid URL - no base path found")
+	}
+
+	c.basePath = c.url[pos:]
+
+	if c.file == "" {
+		return errFilesRequired
+	}
+
+	if c.fileIndexURL == "" {
+		return errFileIndexURLRequired
+	}
+
+	pos = strings.LastIndex(c.fileIndexURL, "/")
+	if pos == -1 {
+		return errors.Errorf("invalid file index URL: [%s]", c.fileIndexURL)
+	}
+
+	if c.fileIndexUpdateOTP == "" {
+		return errFileIndexUpdateOTPRequired
+	}
+
+	if c.fileIndexNextUpdateOTP == "" {
+		return errFileIndexNextUpdateOTPRequired
+	}
+
+	c.fileIndexBaseURL = c.fileIndexURL[0:pos]
+
+	return nil
+}
+
+func (c *command) run() error {
+	fileIdxDoc, err := c.getFileIndexDoc()
+	if err != nil {
+		return err
+	}
+
+	f, err := c.getFiles()
+	if err != nil {
+		return err
+	}
+
+	if !c.noPrompt {
+		confirmed, e := c.confirmUpload(c.url, f)
+		if e != nil {
+			return e
+		}
+
+		if !confirmed {
+			return c.Fprintln(msgAborted)
+		}
+	}
+
+	for _, file := range f {
+		id, e := c.upload(c.url, file.ContentType, file.Content)
+		if e != nil {
+			return e
+		}
+
+		file.ID = id
+	}
+
+	err = c.updateIndexFile(fileIdxDoc, f)
+	if err != nil {
+		return err
+	}
+
+	return c.Fprint(f.String())
+}
+
+// confirmUpload prompts the user for confirmation of the upload
+func (c *command) confirmUpload(url string, files files) (bool, error) {
+	prompt := fmt.Sprintf("Uploading the following files to [%s]\n%s\n%s", url, files, msgContinueOrAbort)
+
+	err := c.Fprintln(prompt)
+	if err != nil {
+		return false, err
+	}
+
+	return strings.ToLower(c.Prompt()) == "y", nil
+}
+
+func (c *command) upload(url, contentType string, fileBytes []byte) (string, error) {
+	req := &uploadFile{
+		ContentType: contentType,
+		Content:     fileBytes,
+	}
+
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.client.Post(url, reqBytes)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.Errorf("status code %d: %s", resp.StatusCode, resp.ErrorMsg)
+	}
+
+	var fileID string
+	err = json.Unmarshal(resp.Payload, &fileID)
+	if err != nil {
+		return "", err
+	}
+
+	return fileID, nil
+}
+
+func (c *command) updateIndexFile(fileIdxDoc document.Document, files files) error {
+	patch, err := getUpdatePatch(fileIdxDoc, files)
+	if err != nil {
+		return err
+	}
+
+	req, err := c.getUpdateRequest(patch)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.client.Post(c.fileIndexBaseURL, req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.Errorf("error updating file index document. Status code %d: %s", resp.StatusCode, resp.ErrorMsg)
+	}
+
+	return err
+}
+
+func (c *command) getFiles() (files, error) {
+	var f files
+	for _, filePath := range strings.Split(c.file, ";") {
+		fileInfo, err := getFileInfo(filePath)
+		if err != nil {
+			return nil, err
+		}
+
+		f = append(f, fileInfo)
+	}
+
+	return f, nil
+}
+
+func (c *command) getUpdateRequest(patch jsonpatch.Patch) ([]byte, error) {
+	uniqueSuffix, err := getUniqueSuffix(c.fileIndexURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return helper.NewUpdateRequest(&helper.UpdateRequestInfo{
+		DidUniqueSuffix: uniqueSuffix,
+		UpdateOTP:       docutil.EncodeToString([]byte(c.fileIndexUpdateOTP)),
+		NextUpdateOTP:   docutil.EncodeToString([]byte(c.fileIndexNextUpdateOTP)),
+		Patch:           patch,
+		MultihashCode:   sha2_256,
+	})
+}
+
+func (c *command) getFileIndexDoc() (document.Document, error) {
+	resp, err := c.client.Get(c.fileIndexURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, errors.Errorf("file index document [%s] not found", c.fileIndexURL)
+		}
+
+		return nil, errors.Errorf("error retrieving file index document [%s] status code %d: %s", c.fileIndexURL, resp.StatusCode, resp.ErrorMsg)
+	}
+
+	var doc document.Document
+	err = json.Unmarshal(resp.Payload, &doc)
+	if err != nil {
+		return nil, err
+	}
+
+	basePath, ok := doc["."]
+	if ok {
+		// Validate that the base path is correct
+		if basePath != c.basePath {
+			return nil, errors.Errorf("base path of file index doc does not match the base path of the file: [%s] != [%s]", basePath, c.basePath)
+		}
+	}
+
+	return doc, nil
+}
+
+func getFileInfo(path string) (*fileInfo, error) {
+	var fileName string
+	p := strings.LastIndex(path, "/")
+	if p == -1 {
+		fileName = path
+	} else {
+		fileName = path[p+1:]
+	}
+
+	contentType, err := contentTypeFromFileName(fileName)
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := ioutil.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+
+	return &fileInfo{
+		Name:        fileName,
+		Content:     content,
+		ContentType: contentType,
+	}, nil
+}
+
+func contentTypeFromFileName(fileName string) (string, error) {
+	p := strings.LastIndex(fileName, ".")
+	if p == -1 {
+		return "", errNoFileExtension
+	}
+
+	contentType := mime.TypeByExtension(fileName[p:])
+	if contentType == "" {
+		return "", errUnknownExtension
+	}
+
+	return contentType, nil
+}
+
+func getUpdatePatch(fileIdxDoc document.Document, files files) (jsonpatch.Patch, error) {
+	var patch []jsonPatch
+	for _, f := range files {
+		p := jsonPatch{
+			Path:  "/" + f.Name,
+			Value: f.ID,
+		}
+
+		if _, ok := fileIdxDoc[f.Name]; ok {
+			p.Op = "replace"
+		} else {
+			p.Op = "add"
+		}
+
+		patch = append(patch, p)
+	}
+
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonPatch, err := jsonpatch.DecodePatch(patchBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return jsonPatch, nil
+}
+
+func getUniqueSuffix(id string) (string, error) {
+	p := strings.LastIndex(id, ":")
+	if p == -1 {
+		return "", errors.Errorf("unique suffix not provided in URL [%s]", id)
+	}
+
+	return id[p+1:], nil
+}

--- a/cmd/file/uploadcmd/uploadcmd_test.go
+++ b/cmd/file/uploadcmd/uploadcmd_test.go
@@ -1,0 +1,258 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package uploadcmd
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/fabric-cli/pkg/environment"
+
+	"github.com/trustbloc/fabric-cli-ext/cmd/file/httpclient"
+	"github.com/trustbloc/fabric-cli-ext/cmd/mocks"
+)
+
+func TestUloadCmd_New(t *testing.T) {
+	require.NotNil(t, New(environment.NewDefaultSettings()))
+}
+
+func TestUloadCmd_InvalidOptions(t *testing.T) {
+	const (
+		urlFlag    = "--url"
+		url        = "http://localhost:80/content"
+		filesFlag  = "--files"
+		files      = "./samplefile.json"
+		idxUrlFlag = "--idxurl"
+		idxUrl     = "http://localhost:80/file/file:idx:1234"
+		pwdFlag    = "--pwd"
+		pwd        = "pwd1"
+	)
+
+	t.Run("No options", func(t *testing.T) {
+		require.EqualError(t, newMockCmd(t, nil).Execute(), errURLRequired.Error())
+	})
+
+	t.Run("Invalid --url", func(t *testing.T) {
+		err := newMockCmd(t, nil, urlFlag, "localhost:80").Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid URL")
+	})
+
+	t.Run("No --files", func(t *testing.T) {
+		require.EqualError(t, newMockCmd(t, nil, urlFlag, url).Execute(), errFilesRequired.Error())
+	})
+
+	t.Run("No --idxurl", func(t *testing.T) {
+		require.EqualError(t, newMockCmd(t, nil, urlFlag, url, filesFlag, files).Execute(), errFileIndexURLRequired.Error())
+	})
+
+	t.Run("Invalid --idxurl", func(t *testing.T) {
+		err := newMockCmd(t, nil, urlFlag, url, filesFlag, files, idxUrlFlag, "localhost:80").Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid file index URL")
+	})
+
+	t.Run("No --pwd", func(t *testing.T) {
+		require.EqualError(t, newMockCmd(t, nil, urlFlag, url, filesFlag, files, idxUrlFlag, idxUrl).Execute(), errFileIndexUpdateOTPRequired.Error())
+	})
+
+	t.Run("No --nextpwd", func(t *testing.T) {
+		require.EqualError(t, newMockCmd(t, nil, urlFlag, url, filesFlag, files, idxUrlFlag, idxUrl, pwdFlag, pwd).Execute(), errFileIndexNextUpdateOTPRequired.Error())
+	})
+}
+
+func TestUploadCmd(t *testing.T) {
+	const (
+		url        = "http://localhost:48326/content"
+		files      = "./testdata/person.schema.json"
+		idxUrl     = "http://localhost:48326/file/file:idx:EiAuN66iEpuRt6IIu-2sO3bRM74sS_AIuY6jTbtFUsqAaA=="
+		fileIDXDoc = `{".":"/content","id":"file:idx:EiAuN66iEpuRt6IIu-2sO3bRM74sS_AIuY6jTbtFUsqAaA==","published":false}`
+		resp       = `[{"Name":"person.schema.json","ID":"TbVyraOqG00TacPQH5WwWGnxkszpYSEhBKRyX_f25JI=","ContentType":"application/json"}]`
+		dcasIDJSON = `"TbVyraOqG00TacPQH5WwWGnxkszpYSEhBKRyX_f25JI="`
+	)
+
+	var (
+		args   = []string{"--url", url, "--files", files, "--idxurl", idxUrl, "--pwd", "pwd1", "--nextpwd", "pwd2"}
+		header = map[string][]string{"Content-Type": {"application/json"}}
+	)
+
+	transport := mocks.NewTransport().
+		WithGetResponse(
+			&http.Response{
+				StatusCode: http.StatusOK,
+				Header:     header,
+				Body:       mocks.NewResponseBody([]byte(fileIDXDoc)),
+			},
+		).
+		WithPostResponse(
+			&http.Response{
+				StatusCode: http.StatusOK,
+				Header:     header,
+				Body:       mocks.NewResponseBody([]byte(dcasIDJSON)),
+			},
+		)
+
+	t.Run("With prompt - Y", func(t *testing.T) {
+		w := &mocks.Writer{}
+
+		c := newMockCmdWithReaderWriter(t, &mocks.Reader{Bytes: []byte("Y\n")}, w, transport, args...)
+		require.NoError(t, c.Execute())
+		require.Contains(t, w.Written(), msgContinueOrAbort)
+		require.Contains(t, w.Written(), resp)
+	})
+
+	t.Run("With --noprompt", func(t *testing.T) {
+		w := &mocks.Writer{}
+
+		c := newMockCmdWithReaderWriter(t, &mocks.Reader{Bytes: []byte("Y\n")}, w, transport, append(args, "--noprompt")...)
+		require.NoError(t, c.Execute())
+		require.NotContains(t, w.Written(), msgContinueOrAbort)
+		require.Contains(t, w.Written(), resp)
+	})
+
+	t.Run("With prompt - N", func(t *testing.T) {
+		w := &mocks.Writer{}
+
+		c := newMockCmdWithReaderWriter(t, &mocks.Reader{Bytes: []byte("N\n")}, w, transport, args...)
+		require.NoError(t, c.Execute())
+		require.Contains(t, w.Written(), msgContinueOrAbort)
+		require.Contains(t, w.Written(), msgAborted)
+		require.NotContains(t, w.Written(), resp)
+	})
+
+	t.Run("With prompt - output stream error", func(t *testing.T) {
+		errExpected := errors.New("output stream error")
+		w := &mocks.Writer{Err: errExpected}
+		c := newMockCmdWithReaderWriter(t, &mocks.Reader{Bytes: []byte("N\n")}, w, transport, args...)
+		require.EqualError(t, c.Execute(), errExpected.Error())
+	})
+
+	t.Run("With GET error", func(t *testing.T) {
+		errExpected := errors.New("injected error")
+
+		transport := mocks.NewTransport().WithGetError(errExpected)
+
+		c := newMockCmd(t, transport, append(args, "--noprompt")...)
+		err := c.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+	})
+
+	t.Run("With POST error", func(t *testing.T) {
+		errExpected := errors.New("injected error")
+
+		transport := mocks.NewTransport().
+			WithGetResponse(
+				&http.Response{
+					StatusCode: http.StatusOK,
+					Header:     header,
+					Body:       mocks.NewResponseBody([]byte(fileIDXDoc)),
+				},
+			).
+			WithPostError(errExpected)
+
+		c := newMockCmd(t, transport, append(args, "--noprompt")...)
+		err := c.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+	})
+
+	t.Run("With HTTP error", func(t *testing.T) {
+		expectedResponse := "server error"
+
+		transport := mocks.NewTransport().WithGetResponse(
+			&http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Header:     header,
+				Body:       mocks.NewResponseBody([]byte(expectedResponse)),
+			},
+		)
+
+		c := newMockCmd(t, transport, append(args, "--noprompt")...)
+		err := c.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), expectedResponse)
+	})
+
+	t.Run("File IDX doc not found", func(t *testing.T) {
+		transport := mocks.NewTransport().WithGetResponse(
+			&http.Response{
+				StatusCode: http.StatusNotFound,
+				Header:     header,
+				Body:       mocks.NewResponseBody([]byte("not found")),
+			},
+		)
+
+		c := newMockCmd(t, transport, append(args, "--noprompt")...)
+		err := c.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("With invalid base path", func(t *testing.T) {
+		const mismatchedFileIDXDoc = `{".":"/schema","id":"file:idx:EiAuN66iEpuRt6IIu-2sO3bRM74sS_AIuY6jTbtFUsqAaA==","published":false}`
+
+		transport := mocks.NewTransport().
+			WithGetResponse(
+				&http.Response{
+					StatusCode: http.StatusOK,
+					Header:     header,
+					Body:       mocks.NewResponseBody([]byte(mismatchedFileIDXDoc)),
+				},
+			)
+
+		c := newMockCmd(t, transport, append(args, "--noprompt")...)
+		err := c.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "base path of file index doc does not match the base path of the file")
+	})
+}
+
+func TestContentTypeFromFileName(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		contentType, err := contentTypeFromFileName("file.json")
+		require.NoError(t, err)
+		require.Equal(t, "application/json", contentType)
+	})
+
+	t.Run("No extension -> error", func(t *testing.T) {
+		contentType, err := contentTypeFromFileName("file")
+		require.EqualError(t, err, errNoFileExtension.Error())
+		require.Empty(t, contentType)
+	})
+
+	t.Run("No extension -> error", func(t *testing.T) {
+		contentType, err := contentTypeFromFileName("file.xxx")
+		require.EqualError(t, err, errUnknownExtension.Error())
+		require.Empty(t, contentType)
+	})
+}
+
+func newMockCmd(t *testing.T, rt http.RoundTripper, args ...string) *cobra.Command {
+	return newMockCmdWithReaderWriter(t, &mocks.Reader{}, &mocks.Writer{}, rt, args...)
+}
+
+func newMockCmdWithReaderWriter(t *testing.T, in io.Reader, w io.Writer, transport http.RoundTripper, args ...string) *cobra.Command {
+	settings := environment.NewDefaultSettings()
+	settings.Streams.Out = w
+	settings.Streams.In = in
+
+	settings.Config.CurrentContext = "testctx"
+	settings.Config.Contexts[settings.Config.CurrentContext] = &environment.Context{}
+
+	c := newCmd(settings, httpclient.New(httpclient.WithTransport(transport)))
+	require.NotNil(t, c)
+
+	c.SetArgs(args)
+
+	return c
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@
 module github.com/trustbloc/fabric-cli-ext
 
 require (
+	github.com/evanphx/json-patch v4.1.0+incompatible
 	github.com/hyperledger/fabric-cli v0.0.0-20191215205855-97c039341083
 	github.com/hyperledger/fabric-sdk-go v1.0.0-beta1.0.20200222173625-ff3bdd738791
 	github.com/pkg/errors v0.8.1


### PR DESCRIPTION
The 'file upload' sub-command allows a client to upload files to DCAS and add their ID's to a file index document.

closes #41

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>