### PR TITLE
feat: Added 'ledgerconfig fileidxupdate' command

### DIFF
--- a/cmd/ledgerconfig/common/keyvalue.go
+++ b/cmd/ledgerconfig/common/keyvalue.go
@@ -1,0 +1,61 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"fmt"
+)
+
+// Key is used to uniquely identify a specific application configuration and is used as the
+// key when persisting to a state store.
+type Key struct {
+	// MspID is the ID of the MSP that owns the data
+	MspID string
+	// PeerID is the (optional) ID of the peer with which the data is associated
+	PeerID string `json:",omitempty"`
+	// AppName is the name of the application that owns the data
+	AppName string
+	// AppVersion is the version of the application config
+	AppVersion string
+	// ComponentName is the (optional) name of the application component
+	ComponentName string `json:",omitempty"`
+	// ComponentVersion is the (optional) version of the application component config
+	ComponentVersion string `json:",omitempty"`
+}
+
+// String returns a readable string for the key
+func (k *Key) String() string {
+	return fmt.Sprintf("(MSP:%s),(Peer:%s),(AppName:%s),(AppVersion:%s),(Comp:%s),(CompVersion:%s)", k.MspID, k.PeerID, k.AppName, k.AppVersion, k.ComponentName, k.ComponentVersion)
+}
+
+// Value contains the configuration data and is persisted as a JSON document in the store.
+type Value struct {
+	// TxID is the ID of the transaction in which the config was stored/updated
+	TxID string
+	// Format describes the format (type) of the config data
+	Format Format
+	// Config contains the actual configuration
+	Config string
+	// Tags contains an optional set of tags that describe the data
+	Tags []string
+}
+
+// String returns a readable string for the value
+func (v *Value) String() string {
+	return fmt.Sprintf("(TxID:%s),(Config:%s),(Format:%s),(Tags:%s)", v.TxID, v.Config, v.Format, v.Tags)
+}
+
+// KeyValue contains the key and the value for the key
+type KeyValue struct {
+	*Key
+	*Value
+}
+
+// String returns a readable string for the key-value
+func (kv *KeyValue) String() string {
+	return fmt.Sprintf("[%s]=[%s]", kv.Key, kv.Value)
+}

--- a/cmd/ledgerconfig/fileidxupdatecmd/fileidxupdatecmd.go
+++ b/cmd/ledgerconfig/fileidxupdatecmd/fileidxupdatecmd.go
@@ -1,0 +1,320 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fileidxupdatecmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hyperledger/fabric-cli/pkg/environment"
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/trustbloc/fabric-cli-ext/cmd/basecmd"
+	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/common"
+)
+
+const (
+	use      = "fileidxupdate"
+	desc     = "Update the ID of the file index document for a given path"
+	longDesc = `
+The fileidxupdate command allows a client to update the file handler configuration of a peer with an ID of a Sidetree file index document`
+	examples = `
+- Updates the ID of the file index Sidetree document in two peers in Org1MSP:
+    $ ./fabric ledgerconfig fileidxupdate --msp Org1MSP --peers peer0.org1.example.com;peer1.org1.example.com --path /content --idxid file:idx:EiAuN66iEpuRt6IIu-2sO3bRM74sS_AIuY6jTbtFUsqAaA== --noprompt
+`
+)
+
+const (
+	mspIDFlag  = "msp"
+	mspIDUsage = `The ID of the MSP. Example: --msp Org1MSP`
+
+	peersFlag  = "peers"
+	peersUsage = "A semi-colon-separated list of peers. Example: --peers peer0.org1.com;peer1.org1.com"
+
+	basePathFlag  = "path"
+	basePathUsage = "The file handler path. Example: --path /schema"
+
+	fileIndexIDFlag  = "idxid"
+	fileIndexIDUsage = "The ID of the file index Sidetree document that is to be updated with the uploaded file. Example: --idxid file:idx:1234"
+
+	noPromptFlag  = "noprompt"
+	noPromptUsage = "If specified then operation will not prompt for confirmation. Example: --noprompt"
+
+	msgConfigUpdated   = "File index successfully updated!"
+	msgAborted         = "Operation aborted"
+	msgContinueOrAbort = "Enter Y to continue or N to abort "
+)
+
+const (
+	configSCC = "configscc"
+
+	fileHandlerAppName          = "file-handler"
+	fileHandlerAppVersion       = "1"
+	fileHandlerComponentVersion = "1"
+)
+
+var (
+	errMSPRequired         = errors.New("msp (--msp) is required")
+	errPeersRequired       = errors.New("peers (--peers) is required")
+	errFileIndexIDRequired = errors.New("file index ID (--idxid) is required")
+	errBasePathRequired    = errors.New("base path (--path) is required")
+)
+
+// New returns the ledgerconfig update sub-command
+func New(settings *environment.Settings) *cobra.Command {
+	return newCmd(settings, nil)
+}
+
+func newCmd(settings *environment.Settings, p basecmd.FactoryProvider) *cobra.Command {
+	c := &command{
+		Command: basecmd.New(settings, p),
+	}
+	cmd := &cobra.Command{
+		Use:     use,
+		Short:   desc,
+		Long:    longDesc,
+		Example: examples,
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			if err := c.validate(); err != nil {
+				return err
+			}
+			return nil
+		},
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return c.run()
+		},
+	}
+
+	c.Settings = settings
+	cmd.SetOutput(c.Settings.Streams.Out)
+	cmd.SilenceUsage = true
+
+	cmd.Flags().StringVar(&c.mspID, mspIDFlag, "", mspIDUsage)
+	cmd.Flags().StringVar(&c.peerID, peersFlag, "", peersUsage)
+	cmd.Flags().StringVar(&c.basePath, basePathFlag, "", basePathUsage)
+	cmd.Flags().StringVar(&c.fileIndexID, fileIndexIDFlag, "", fileIndexIDUsage)
+	cmd.Flags().BoolVar(&c.noPrompt, noPromptFlag, false, noPromptUsage)
+
+	return cmd
+}
+
+// command implements the update command
+type command struct {
+	*basecmd.Command
+
+	// Flags
+	mspID       string
+	peerID      string
+	basePath    string
+	fileIndexID string
+	noPrompt    bool
+}
+
+func (c *command) validate() error {
+	if c.mspID == "" {
+		return errMSPRequired
+	}
+
+	if c.peerID == "" {
+		return errPeersRequired
+	}
+
+	if c.basePath == "" {
+		return errBasePathRequired
+	}
+
+	if c.fileIndexID == "" {
+		return errFileIndexIDRequired
+	}
+
+	return nil
+}
+
+func (c *command) run() error {
+	configBytes, err := c.getConfigBytes()
+	if err != nil {
+		return err
+	}
+
+	// Get confirmation from the user
+	if !c.noPrompt {
+		confirmed, e := c.confirmUpdate(configBytes)
+		if e != nil {
+			return e
+		}
+		if !confirmed {
+			return c.Fprintln(msgAborted)
+		}
+	}
+
+	req := channel.Request{
+		ChaincodeID: common.ConfigSCC,
+		Fcn:         "save",
+		Args:        [][]byte{configBytes},
+	}
+
+	ch, err := c.Channel()
+	if err != nil {
+		return err
+	}
+
+	_, err = ch.Execute(req)
+	if err != nil {
+		return err
+	}
+
+	return c.Fprintln(msgConfigUpdated)
+}
+
+type fileHandlerConfig struct {
+	BasePath       string
+	ChaincodeName  string
+	Collection     string
+	IndexNamespace string
+	IndexDocID     string
+}
+
+func (c *command) getConfigBytes() ([]byte, error) {
+	cfgMap, err := c.loadConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &common.Config{
+		MspID: c.mspID,
+	}
+
+	for peerID, handlerCfg := range cfgMap {
+		handlerCfg.IndexDocID = c.fileIndexID
+
+		cfgBytes, err := json.Marshal(handlerCfg)
+		if err != nil {
+			return nil, err
+		}
+
+		peerCfg := &common.Peer{
+			PeerID: peerID,
+			Apps: []*common.App{
+				{
+					AppName: fileHandlerAppName,
+					Version: fileHandlerAppVersion,
+					Components: []*common.Component{
+						{
+							Name:    c.basePath,
+							Version: fileHandlerComponentVersion,
+							Format:  "JSON",
+							Config:  string(cfgBytes),
+						},
+					},
+				},
+			},
+		}
+
+		cfg.Peers = append(cfg.Peers, peerCfg)
+	}
+
+	return json.Marshal(cfg)
+}
+
+func (c *command) loadConfig() (map[string]*fileHandlerConfig, error) {
+	peers := strings.Split(c.peerID, ";")
+
+	cfgMap := make(map[string]*fileHandlerConfig)
+	for _, peerID := range peers {
+		cfg, err := c.loadPeerConfig(peerID)
+		if err != nil {
+			return nil, err
+		}
+
+		if !strings.HasPrefix(c.fileIndexID, cfg.IndexNamespace) {
+			return nil, errors.Errorf("file index ID must begin with [%s]", cfg.IndexNamespace)
+		}
+
+		if cfg.IndexDocID == c.fileIndexID {
+			// Index already set for peerID. Skip this peerID
+			continue
+		}
+
+		cfgMap[peerID] = cfg
+	}
+
+	if len(cfgMap) == 0 {
+		return nil, errors.Errorf("the file index ID for [%s] is already set to [%s]", c.basePath, c.fileIndexID)
+	}
+
+	return cfgMap, nil
+}
+
+func (c *command) loadPeerConfig(peerID string) (*fileHandlerConfig, error) {
+	criteria := &common.Criteria{
+		MspID:            c.mspID,
+		PeerID:           peerID,
+		AppName:          fileHandlerAppName,
+		AppVersion:       fileHandlerAppVersion,
+		ComponentName:    c.basePath,
+		ComponentVersion: fileHandlerComponentVersion,
+	}
+
+	criteriaBytes, err := json.Marshal(criteria)
+	if err != nil {
+		return nil, err
+	}
+
+	req := channel.Request{
+		ChaincodeID: configSCC,
+		Fcn:         "get",
+		Args:        [][]byte{criteriaBytes},
+	}
+
+	ch, err := c.Channel()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := ch.Query(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var queryResults []*common.KeyValue
+	err = json.Unmarshal(resp.Payload, &queryResults)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(queryResults) == 0 {
+		return nil, errors.Errorf("config not found for file handler [%s]", c.basePath)
+	}
+
+	cfg := &fileHandlerConfig{}
+
+	err = json.Unmarshal([]byte(queryResults[0].Value.Config), cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+// confirmUpdate prompts the user for confirmation of the update
+func (c *command) confirmUpdate(config []byte) (bool, error) {
+	displayedJSON, err := common.FormatJSON(config)
+	if err != nil {
+		return false, err
+	}
+
+	prompt := fmt.Sprintf("Updating the configuration with:\n\n%s\n\n%s", displayedJSON, msgContinueOrAbort)
+
+	err = c.Fprintln(prompt)
+	if err != nil {
+		return false, err
+	}
+
+	return strings.ToLower(c.Prompt()) == "y", nil
+}

--- a/cmd/ledgerconfig/fileidxupdatecmd/fileidxupdatecmd_test.go
+++ b/cmd/ledgerconfig/fileidxupdatecmd/fileidxupdatecmd_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fileidxupdatecmd
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/hyperledger/fabric-cli/pkg/environment"
+	"github.com/hyperledger/fabric-cli/pkg/fabric"
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-cli-ext/cmd/basecmd"
+	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/common"
+	"github.com/trustbloc/fabric-cli-ext/cmd/mocks"
+)
+
+func TestNew(t *testing.T) {
+	require.NotNil(t, New(environment.NewDefaultSettings()))
+}
+
+func TestFileIDXUpdateCmd_InvalidOptions(t *testing.T) {
+	const (
+		mspFlag   = "--msp"
+		msp       = "Org1MSP"
+		peersFlag = "--peers"
+		peers     = "peer0.org1.example.com;peer1.org1.example.com"
+		pathFlag  = "--path"
+		path      = "/content"
+	)
+
+	t.Run("No options", func(t *testing.T) {
+		require.EqualError(t, newMockCmd(t, nil).Execute(), errMSPRequired.Error())
+	})
+
+	t.Run("No peers", func(t *testing.T) {
+		require.EqualError(t, newMockCmd(t, nil, mspFlag, msp).Execute(), errPeersRequired.Error())
+	})
+
+	t.Run("No path", func(t *testing.T) {
+		require.EqualError(t, newMockCmd(t, nil, mspFlag, msp, peersFlag, peers).Execute(), errBasePathRequired.Error())
+	})
+
+	t.Run("No file index ID", func(t *testing.T) {
+		require.EqualError(t, newMockCmd(t, nil, mspFlag, msp, peersFlag, peers, pathFlag, path).Execute(), errFileIndexIDRequired.Error())
+	})
+}
+
+func TestFileIDXUpdateCmd_InitializeError(t *testing.T) {
+	args := []string{"--msp", "Org1MSP", "--peers", "peer0.org1.example.com;peer1.org1.example.com", "--path", "/content", "--idxid", "file:idx:EiAuN66iEpuRt6IIu-2sO3bRM74sS_AIuY6jTbtFUsqAaA=="}
+
+	t.Run("With channel error", func(t *testing.T) {
+		errExpected := errors.New("channel error")
+		p := func(config *environment.Config) (fabric.Factory, error) { return nil, errExpected }
+
+		c := newMockCmd(t, p, append(args, "--noprompt")...)
+		require.EqualError(t, c.Execute(), errExpected.Error())
+	})
+}
+
+func TestFileIDXUpdateCmd(t *testing.T) {
+	const (
+		msp  = "Org1MSP"
+		peer = "peer.org1.example.com"
+		path = "/content"
+
+		handlerCfg           = `{"BasePath":"/content","ChaincodeName":"files","Collection":"consortium","IndexNamespace":"file:idx"}`
+		mismatchedHandlerCfg = `{"BasePath":"/content","ChaincodeName":"files","Collection":"consortium","IndexNamespace":"file:xxx"}`
+		setHandlerCfg        = `{"BasePath":"/content","ChaincodeName":"files","Collection":"consortium","IndexNamespace":"file:idx","IndexDocID": "file:idx:EiAuN66iEpuRt6IIu-2sO3bRM74sS_AIuY6jTbtFUsqAaA=="}`
+	)
+
+	args := []string{"--msp", "Org1MSP", "--peers", "peer.org1.example.com;peer1.org1.example.com", "--path", "/content", "--idxid", "file:idx:EiAuN66iEpuRt6IIu-2sO3bRM74sS_AIuY6jTbtFUsqAaA=="}
+
+	factory := &mocks.Factory{}
+	c := &mocks.Channel{}
+
+	factory.ChannelReturns(c, nil)
+
+	p := func(config *environment.Config) (fabric.Factory, error) { return factory, nil }
+
+	key := &common.Key{
+		MspID:            msp,
+		PeerID:           peer,
+		AppName:          fileHandlerAppName,
+		AppVersion:       fileHandlerAppVersion,
+		ComponentName:    path,
+		ComponentVersion: "1",
+	}
+
+	validCfg := &common.KeyValue{
+		Key:   key,
+		Value: &common.Value{TxID: "tx1", Format: "json", Config: handlerCfg},
+	}
+
+	validCfgBytes, err := json.Marshal([]*common.KeyValue{validCfg})
+	require.NoError(t, err)
+
+	validResp := channel.Response{Payload: validCfgBytes}
+
+	t.Run("With --noprompt", func(t *testing.T) {
+		c.QueryReturns(validResp, nil)
+		c := newMockCmd(t, p, append(args, "--noprompt")...)
+		require.NoError(t, c.Execute())
+	})
+
+	t.Run("With prompt - Y", func(t *testing.T) {
+		c.QueryReturns(validResp, nil)
+		w := &mocks.Writer{}
+		c := newMockCmdWithReaderWriter(t, &mocks.Reader{Bytes: []byte("Y\n")}, w, p, args...)
+		require.NoError(t, c.Execute())
+		require.Contains(t, w.Written(), msgContinueOrAbort)
+		require.Contains(t, w.Written(), msgConfigUpdated)
+	})
+
+	t.Run("With prompt - N", func(t *testing.T) {
+		c.QueryReturns(validResp, nil)
+		w := &mocks.Writer{}
+		c := newMockCmdWithReaderWriter(t, &mocks.Reader{Bytes: []byte("N\n")}, w, p, args...)
+		require.NoError(t, c.Execute())
+		require.Contains(t, w.Written(), msgContinueOrAbort)
+		require.Contains(t, w.Written(), msgAborted)
+		require.NotContains(t, w.Written(), msgConfigUpdated)
+	})
+
+	t.Run("With prompt - output stream error", func(t *testing.T) {
+		c.QueryReturns(validResp, nil)
+		errExpected := errors.New("output stream error")
+		w := &mocks.Writer{Err: errExpected}
+		c := newMockCmdWithReaderWriter(t, &mocks.Reader{Bytes: []byte("N\n")}, w, p, args...)
+		require.EqualError(t, c.Execute(), errExpected.Error())
+	})
+
+	t.Run("Invalid file index ID", func(t *testing.T) {
+		cfg := &common.KeyValue{
+			Key:   key,
+			Value: &common.Value{TxID: "tx1", Format: "json", Config: mismatchedHandlerCfg},
+		}
+
+		cfgBytes, err := json.Marshal([]*common.KeyValue{cfg})
+		require.NoError(t, err)
+
+		c.QueryReturns(channel.Response{Payload: cfgBytes}, nil)
+		c := newMockCmd(t, p, append(args, "--noprompt")...)
+
+		err = c.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "file index ID must begin with")
+	})
+
+	t.Run("File index ID already set", func(t *testing.T) {
+		cfg := &common.KeyValue{
+			Key:   key,
+			Value: &common.Value{TxID: "tx1", Format: "json", Config: setHandlerCfg},
+		}
+
+		cfgBytes, err := json.Marshal([]*common.KeyValue{cfg})
+		require.NoError(t, err)
+
+		c.QueryReturns(channel.Response{Payload: cfgBytes}, nil)
+		c := newMockCmd(t, p, append(args, "--noprompt")...)
+
+		err = c.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "the file index ID for [/content] is already set")
+	})
+}
+
+func newMockCmd(t *testing.T, p basecmd.FactoryProvider, args ...string) *cobra.Command {
+	return newMockCmdWithReaderWriter(t, &mocks.Reader{}, &mocks.Writer{}, p, args...)
+}
+
+func newMockCmdWithReaderWriter(t *testing.T, in io.Reader, w io.Writer, p basecmd.FactoryProvider, args ...string) *cobra.Command {
+	settings := environment.NewDefaultSettings()
+	settings.Streams.Out = w
+	settings.Streams.In = in
+
+	settings.Config.CurrentContext = "testctx"
+	settings.Config.Contexts[settings.Config.CurrentContext] = &environment.Context{}
+
+	c := newCmd(settings, p)
+	require.NotNil(t, c)
+
+	c.SetArgs(args)
+
+	return c
+}

--- a/cmd/ledgerconfig/ledgerconfig.go
+++ b/cmd/ledgerconfig/ledgerconfig.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hyperledger/fabric-cli/pkg/environment"
 	"github.com/spf13/cobra"
 	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/deletecmd"
+	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/fileidxupdatecmd"
 	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/querycmd"
 	"github.com/trustbloc/fabric-cli-ext/cmd/ledgerconfig/updatecmd"
 )
@@ -34,6 +35,7 @@ func New(settings *environment.Settings) *cobra.Command {
 		querycmd.New(settings),
 		updatecmd.New(settings),
 		deletecmd.New(settings),
+		fileidxupdatecmd.New(settings),
 	)
 	return cmd
 }

--- a/cmd/ledgerconfig/ledgerconfig_test.go
+++ b/cmd/ledgerconfig/ledgerconfig_test.go
@@ -32,4 +32,6 @@ func TestNew(t *testing.T) {
 	require.Contains(t, w.Written(), "Update ledger configuration")
 	// Make sure that the delete command was added
 	require.Contains(t, w.Written(), "Delete ledger configuration")
+	// Make sure that the fileidxupdate command was added
+	require.Contains(t, w.Written(), "fileidxupdate")
 }


### PR DESCRIPTION
The fileidxupdate command allows a client to update the ID of the file index Sidetree document for a file handler.

closes #43

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>