### PR TITLE
chore: Add support for authorization tokens

### DIFF
--- a/cmd/file/createidxcmd/createidxcmd_test.go
+++ b/cmd/file/createidxcmd/createidxcmd_test.go
@@ -108,7 +108,7 @@ func TestCreateIDXCmd(t *testing.T) {
 	didResolutionBytes, err := json.Marshal(didResolution)
 	require.NoError(t, err)
 
-	args := []string{"--url", "http://localhost:80/file", "--path", "/content", "--recoverypwd", "pwd1", "--nextpwd", "pwd1", "--recoverykey", recoveryPublicKey, "--updatekey", updatePublicKey}
+	args := []string{"--url", "http://localhost:80/file", "--path", "/content", "--recoverypwd", "pwd1", "--nextpwd", "pwd1", "--recoverykey", recoveryPublicKey, "--updatekey", updatePublicKey, "--authtoken", "mytoken"}
 	header := map[string][]string{"Content-Type": {"application/json"}}
 
 	transport := mocks.NewTransport().WithPostResponse(

--- a/cmd/file/httpclient/httpclient_test.go
+++ b/cmd/file/httpclient/httpclient_test.go
@@ -34,7 +34,7 @@ func TestClient(t *testing.T) {
 		c := New(WithTransport(transport))
 		require.NotNil(t, c)
 
-		resp, err := c.Get("http://localhost:80")
+		resp, err := c.Get("http://localhost:80", WithAuthToken("mytoken"))
 		require.NoError(t, err)
 		require.Equal(t, respData, resp.Payload)
 	})
@@ -52,7 +52,7 @@ func TestClient(t *testing.T) {
 		c := New(WithTransport(transport))
 		require.NotNil(t, c)
 
-		resp, err := c.Post("http://localhost:80", reqData)
+		resp, err := c.Post("http://localhost:80", reqData, WithAuthToken("mytoken"))
 		require.NoError(t, err)
 		require.Equal(t, respData, resp.Payload)
 	})

--- a/cmd/file/model/model.go
+++ b/cmd/file/model/model.go
@@ -10,7 +10,7 @@ import "encoding/json"
 
 const (
 	// UpdateKeyID is the ID of the public key within the document that is used for signature verification of updates
-	UpdateKeyID = "#updatePublicKey"
+	UpdateKeyID = "updatePublicKey"
 )
 
 // FileIndexDoc contains a file index document

--- a/cmd/ledgerconfig/fileidxupdatecmd/fileidxupdatecmd.go
+++ b/cmd/ledgerconfig/fileidxupdatecmd/fileidxupdatecmd.go
@@ -172,7 +172,16 @@ func (c *command) run() error {
 	return c.Fprintln(msgConfigUpdated)
 }
 
+type authConfig struct {
+	// ReadTokens contains a set of names of tokens for authorizing read requests
+	ReadTokens []string
+	// WriteTokens contains a set of names of tokens for authorizing write requests
+	WriteTokens []string
+}
+
 type fileHandlerConfig struct {
+	Authorization authConfig
+
 	BasePath       string
 	ChaincodeName  string
 	Collection     string

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.4
 	github.com/stretchr/testify v1.4.0
-	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954
+	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429132924-5ec11da3314b
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -205,11 +205,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200413003843-9b61fc7e397b h1:0neYCsQi1nZmEFnVdPIJiq4FrHq7X2DocYRGu8Eab/8=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200413003843-9b61fc7e397b/go.mod h1:4Z1Zrxs/ut+fGmTdliYAc6sVueXb07EFJHKC/5VOvQA=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200420215423-0c6a32299a30 h1:bd/u3vgi2ZGYBenKTooTV9FiYMfIkhzCTXt/nAUiDmg=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200420215423-0c6a32299a30/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429132924-5ec11da3314b h1:wVscI1/+oJq3bYvyPiRTytZo9+HCU0GZ76wuGzAQbGQ=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429132924-5ec11da3314b/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/test/bddtests/fabriccli_steps.go
+++ b/test/bddtests/fabriccli_steps.go
@@ -7,9 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package bddtests
 
 import (
-	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"strings"
 
@@ -92,45 +89,6 @@ func (d *FabricCLISteps) execute(strArgs string) error {
 	return nil
 }
 
-func (d *FabricCLISteps) httpGet(url string) error {
-	bddtests.ClearResponse()
-
-	resolved, err := bddtests.ResolveVars(url)
-	if err != nil {
-		return err
-	}
-
-	url = resolved.(string)
-
-	client := &http.Client{}
-
-	resp, err := client.Get(url)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return errors.Errorf("received status code %d", resp.StatusCode)
-	}
-
-	contentType, ok := resp.Header["Content-Type"]
-	if ok && strings.HasPrefix(contentType[0], "image") {
-		logger.Infof("... got HTTP image of type [%s]", contentType)
-		return nil
-	}
-
-	payload, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("reading response body failed: %s", err)
-	}
-
-	logger.Infof("... got HTTP response of type [%s]:\n%s", contentType[0], payload)
-
-	bddtests.SetResponse(string(payload))
-
-	return nil
-}
-
 // RegisterSteps registers transient data steps
 func (d *FabricCLISteps) RegisterSteps(s *godog.Suite) {
 	s.BeforeScenario(d.BDDContext.BeforeScenario)
@@ -140,5 +98,4 @@ func (d *FabricCLISteps) RegisterSteps(s *godog.Suite) {
 	s.Step(`^fabric-cli context "([^"]*)" is defined on channel "([^"]*)" with org "([^"]*)", peers "([^"]*)" and user "([^"]*)"$`, d.defineContext)
 	s.Step(`^fabric-cli context "([^"]*)" is used$`, d.useContext)
 	s.Step(`^fabric-cli is executed with args "([^"]*)"$`, d.execute)
-	s.Step(`^an HTTP request is sent to "([^"]*)"$`, d.httpGet)
 }

--- a/test/bddtests/features/step_definitions/common_steps.js
+++ b/test/bddtests/features/step_definitions/common_steps.js
@@ -67,10 +67,67 @@ defineSupportCode(function ({And, But, Given, Then, When}) {
     Then(/^the JSON path "([^"]*)" of the response equals "([^"]*)"$/, function (arg1, arg2, callback) {
         callback.pending();
     });
+    Then(/^the JSON path "([^"]*)" of the numeric response equals "([^"]*)"$/, function (arg1, arg2, callback) {
+        callback.pending();
+    });
+    Then(/^the JSON path "([^"]*)" of the boolean response equals "([^"]*)"$/, function (arg1, arg2, callback) {
+        callback.pending();
+    });
     Then(/^the JSON path "([^"]*)" of the response contains "([^"]*)"$/, function (arg1, arg2, callback) {
         callback.pending();
     });
     Then(/^the JSON path "([^"]*)" of the response is saved to variable "([^"]*)"$/, function (arg1, arg2, callback) {
+        callback.pending();
+    });
+    Then(/^the JSON path "([^"]*)" of the numeric response is saved to variable "([^"]*)"$/, function (arg1, arg2, callback) {
+        callback.pending();
+    });
+    Then(/^the JSON path "([^"]*)" of the boolean response is saved to variable "([^"]*)"$/, function (arg1, arg2, callback) {
+        callback.pending();
+    });
+    Then(/^the JSON path "([^"]*)" of the raw response is saved to variable "([^"]*)"$/, function (arg1, arg2, callback) {
+        callback.pending();
+    });
+    Then(/^the JSON path "([^"]*)" of the response is not empty$/, function (arg1, callback) {
+        callback.pending();
+    });
+    Then(/^the JSON path "([^"]*)" of the array response is not empty$/, function (arg1, callback) {
+        callback.pending();
+    });
+    And(/^an HTTP GET is sent to "([^"]*)"$/, function (arg1, callback) {
+        callback.pending();
+    });
+    And(/^an HTTP GET is sent to "([^"]*)" and the returned status code is (\d+)$/, function (arg1, arg2, callback) {
+        callback.pending();
+    });
+    And(/^an HTTP POST is sent to "([^"]*)" with content from file "([^"]*)"$/, function (arg1, arg2, callback) {
+        callback.pending();
+    });
+    And(/^an HTTP POST is sent to "([^"]*)" with content from file "([^"]*)" and the returned status code is (\d+)$/, function (arg1, arg2, arg3, callback) {
+        callback.pending();
+    });
+    And(/^an HTTP POST is sent to "([^"]*)" with content "([^"]*)" of type "([^"]*)"$/, function (arg1, arg2, arg3, callback) {
+        callback.pending();
+    });
+    And(/^an HTTP POST is sent to "([^"]*)" with content "([^"]*)" of type "([^"]*)" and the returned status code is (\d+)$/, function (arg1, arg2, arg3, arg4, callback) {
+        callback.pending();
+    });
+    Then(/^the response equals "([^"]*)"$/, function (arg1, callback) {
+        callback.pending();
+    });
+    And(/^the base64-encoded value "([^"]*)" is converted to base64URL-encoding and saved to variable "([^"]*)"$/, function (arg1, arg2, callback) {
+        callback.pending();
+    });
+    And(/^the base64-encoded value "([^"]*)" is decoded and saved to variable "([^"]*)"$/, function (arg1, arg2, callback) {
+        callback.pending();
+    });
+    And(/^the value "([^"]*)" equals "([^"]*)"$/, function (arg1, arg2, callback) {
+        callback.pending();
+    });
+    And(/^variable "([^"]*)" is assigned the value "([^"]*)"$/, function (arg1, arg2, callback) {
+        callback.pending();
+    });
+    And(/^the authorization bearer token for "([^"]*)" requests to path "([^"]*)" is set to "([^"]*)"$/, function (arg1, arg2, callback) {
         callback.pending();
     });
 });

--- a/test/bddtests/features/step_definitions/fabriccli_steps.js
+++ b/test/bddtests/features/step_definitions/fabriccli_steps.js
@@ -22,7 +22,4 @@ defineSupportCode(function ({And, But, Given, Then, When}) {
     And(/^fabric-cli is executed with args "([^"]*)"$/, function (arg1, callback) {
         callback.pending();
     });
-    And(/^an HTTP request is sent to "([^"]*)"$/, function (arg1, callback) {
-        callback.pending();
-    });
 });

--- a/test/bddtests/fixtures/.env
+++ b/test/bddtests/fixtures/.env
@@ -29,7 +29,7 @@ FABRIC_ORDERER_FIXTURE_TAG=2.0.0
 
 # sidetree-fabric peer
 FABRIC_PEER_FIXTURE_IMAGE=docker.pkg.github.com/trustbloc/sidetree-fabric/peer
-FABRIC_PEER_FIXTURE_TAG=0.1.3-snapshot-e3b60fa
+FABRIC_PEER_FIXTURE_TAG=0.1.3-snapshot-0cad0cd
 
 # fabric cc env
 FABRIC_BUILDER_FIXTURE_IMAGE=fabric-ccenv

--- a/test/bddtests/fixtures/config/fabric/filehandler-content-config.json
+++ b/test/bddtests/fixtures/config/fabric/filehandler-content-config.json
@@ -3,5 +3,8 @@
   "ChaincodeName": "file",
   "Collection": "consortium",
   "IndexNamespace": "file:idx",
-  "IndexDocID": ""
+  "IndexDocID": "",
+  "Authorization":{
+    "WriteTokens": ["content_w","fileidx_w"]
+  }
 }

--- a/test/bddtests/fixtures/config/fabric/sidetree-config.json
+++ b/test/bddtests/fixtures/config/fabric/sidetree-config.json
@@ -7,7 +7,11 @@
     {
       "DocType": "FILE_INDEX",
       "Namespace": "file:idx",
-      "BasePath": "/file"
+      "BasePath": "/file",
+      "Authorization":{
+        "ReadTokens": ["fileidx_r","fileidx_w"],
+        "WriteTokens": ["fileidx_w"]
+      }
     }
   ]
 }

--- a/test/bddtests/fixtures/docker-compose-base.yml
+++ b/test/bddtests/fixtures/docker-compose-base.yml
@@ -1,0 +1,43 @@
+#
+# Copyright IBM Corp, SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+version: '2'
+
+services:
+  peer:
+    image: ${FABRIC_PEER_FIXTURE_IMAGE}:${ARCH}-${FABRIC_PEER_FIXTURE_TAG}
+    environment:
+      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
+      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:endorser=warn:sidetree_peer=debug:sidetree_context=debug:sidetree_observer=debug:ext_offledger=info:ext_dispatcher=info:chaincode=info:cceventmgmt=info:ext_gossip_state=info:info
+      - CORE_VM_DOCKER_ATTACHSTDOUT=true
+      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer/
+      - CORE_PEER_TLS_ENABLED=true
+      - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
+      - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
+      - CORE_PEER_TLS_CLIENTCERT_FILE=/etc/hyperledger/fabric/tls/server.crt
+      - CORE_PEER_TLS_CLIENTKEY_FILE=/etc/hyperledger/fabric/tls/server.key
+      - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/fabric/tls/ca.crt
+      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
+      - CORE_PEER_TLS_CLIENTROOTCAS_FILES=/etc/hyperledger/fabric/tls/ca.crt /etc/hyperledger/mutual_tls/peer/ca.crt
+      - CORE_CHAINCODE_BUILDER=${TRUSTBLOCK_NS}/${FABRIC_BUILDER_FIXTURE_IMAGE}:${ARCH}-${FABRIC_BUILDER_FIXTURE_TAG}
+      - CORE_CHAINCODE_GOLANG_RUNTIME=${FABRIC_NS}/${FABRIC_BASEOS_FIXTURE_IMAGE}:${FABRIC_BASEOS_FIXTURE_TAG}
+      - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
+      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fixtures_default
+      - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
+      - CORE_LEDGER_TRANSIENTDATA_CACHESIZE=1000
+      - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=shared.couchdb:5984
+      - CORE_LEDGER_STATE_DBCONFIG_PARTITIONTYPE=PEER
+      - CORE_SIDETREE_PORT=48326
+      - CORE_SIDETREE_API_TOKENS=content_w=TOKEN_CONTENT_W:fileidx_r=TOKEN_FILEIDX_R:fileidx_w=TOKEN_FILEIDX_W
+    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
+    tty: true
+    volumes:
+      - /var/run/:/host/var/run/
+      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
+      - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
+      - ${COMPOSE_DIR}/config/fabric/core.yaml:/etc/hyperledger/fabric/core.yaml

--- a/test/bddtests/fixtures/docker-compose.yml
+++ b/test/bddtests/fixtures/docker-compose.yml
@@ -30,224 +30,89 @@ services:
       - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/msp:/etc/hyperledger/msp/orderer
       - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls:/etc/hyperledger/tls/orderer
       - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls/ca.crt:/etc/hyperledger/mutual_tls/orderer/ca.crt
+
   peer0.org1.example.com:
+    extends:
+      file: docker-compose-base.yml
+      service: peer
     container_name: peer0.org1.example.com
-    image: ${FABRIC_PEER_FIXTURE_IMAGE}:${ARCH}-${FABRIC_PEER_FIXTURE_TAG}
     environment:
-      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
-      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:info
-      ## the following setting redirects chaincode container logs to the peer container logs
-      - CORE_VM_DOCKER_ATTACHSTDOUT=true
       - CORE_PEER_LOCALMSPID=Org1MSP
-      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer/
       - CORE_PEER_ADDRESS=peer0.org1.example.com:7051
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org1.example.com:7051
-      - CORE_PEER_TLS_ENABLED=true
-      - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_CLIENTCERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_CLIENTKEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/fabric/tls/ca.crt
-      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
-      - CORE_PEER_TLS_CLIENTROOTCAS_FILES=/etc/hyperledger/fabric/tls/ca.crt /etc/hyperledger/mutual_tls/peer/ca.crt
-      # override chaincode images
-      - CORE_CHAINCODE_BUILDER=${TRUSTBLOCK_NS}/${FABRIC_BUILDER_FIXTURE_IMAGE}:${ARCH}-${FABRIC_BUILDER_FIXTURE_TAG}
-      - CORE_CHAINCODE_GOLANG_RUNTIME=${FABRIC_NS}/${FABRIC_BASEOS_FIXTURE_IMAGE}:${FABRIC_BASEOS_FIXTURE_TAG}
-      - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
-      # # the following setting starts chaincode containers on the same
-      # # bridge network as the peers
-      # # https://docs.docker.com/compose/networking/
-      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fixtures_default
-      # CouchDB Settings
-      - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
-      - CORE_LEDGER_TRANSIENTDATA_CACHESIZE=1000
-      - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=shared.couchdb:5984
-      - CORE_LEDGER_STATE_DBCONFIG_PARTITIONTYPE=PEER
       - CORE_LEDGER_ROLES=endorser,committer,sidetree-resolver,sidetree-batch-writer,sidetree-monitor
-      - CORE_SIDETREE_PORT=48326
-    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
-    tty: true
     ports:
       - 7051:7051
       - 48326:48326
     volumes:
-      - /var/run/:/host/var/run/
       - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp:/etc/hyperledger/msp/peer
       - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls:/etc/hyperledger/fabric/tls
-      # Give Snap the orderer CA
-      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
-      - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
-      - ${COMPOSE_DIR}/config/fabric/core.yaml:/etc/hyperledger/fabric/core.yaml
     depends_on:
       - builder
       - orderer.example.com
+
   peer1.org1.example.com:
+    extends:
+      file: docker-compose-base.yml
+      service: peer
     container_name: peer1.org1.example.com
-    image: ${FABRIC_PEER_FIXTURE_IMAGE}:${ARCH}-${FABRIC_PEER_FIXTURE_TAG}
     environment:
-      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org1.example.com
-      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:info
-      ## the following setting redirects chaincode container logs to the peer container logs
-      - CORE_VM_DOCKER_ATTACHSTDOUT=true
       - CORE_PEER_LOCALMSPID=Org1MSP
-      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer/
       - CORE_PEER_ADDRESS=peer1.org1.example.com:7051
       - CORE_PEER_GOSSIP_BOOTSTRAP=peer0.org1.example.com:7051
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer1.org1.example.com:7051
-      - CORE_PEER_TLS_ENABLED=true
-      - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_CLIENTCERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_CLIENTKEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/fabric/tls/ca.crt
-      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
-      - CORE_PEER_TLS_CLIENTROOTCAS_FILES=/etc/hyperledger/fabric/tls/ca.crt /etc/hyperledger/mutual_tls/peer/ca.crt
-      # override chaincode images
-      - CORE_CHAINCODE_BUILDER=${TRUSTBLOCK_NS}/${FABRIC_BUILDER_FIXTURE_IMAGE}:${ARCH}-${FABRIC_BUILDER_FIXTURE_TAG}
-      - CORE_CHAINCODE_GOLANG_RUNTIME=${FABRIC_NS}/${FABRIC_BASEOS_FIXTURE_IMAGE}:${FABRIC_BASEOS_FIXTURE_TAG}
-      - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
-      # # the following setting starts chaincode containers on the same
-      # # bridge network as the peers
-      # # https://docs.docker.com/compose/networking/
-      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fixtures_default
-      # CouchDB Settings
-      - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
-      - CORE_LEDGER_TRANSIENTDATA_CACHESIZE=1000
-      - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=shared.couchdb:5984
-      - CORE_LEDGER_STATE_DBCONFIG_PARTITIONTYPE=PEER
       - CORE_LEDGER_ROLES=endorser,committer,sidetree-resolver,sidetree-batch-writer,sidetree-observer
-      - CORE_SIDETREE_PORT=48326
-    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
-    tty: true
     ports:
       - 7151:7051
       - 48426:48326
     volumes:
-      - /var/run/:/host/var/run/
       - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer1.org1.example.com/msp:/etc/hyperledger/msp/peer
       - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer1.org1.example.com/tls:/etc/hyperledger/fabric/tls
-      # Give Snap the orderer CA
-      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
-      - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
-      - ${COMPOSE_DIR}/config/fabric/core.yaml:/etc/hyperledger/fabric/core.yaml
     depends_on:
       - builder
       - orderer.example.com
 
   peer0.org2.example.com:
+    extends:
+      file: docker-compose-base.yml
+      service: peer
     container_name: peer0.org2.example.com
-    image: ${FABRIC_PEER_FIXTURE_IMAGE}:${ARCH}-${FABRIC_PEER_FIXTURE_TAG}
     environment:
-      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
-      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:info
-      ## the following setting redirects chaincode container logs to the peer container logs
-      - CORE_VM_DOCKER_ATTACHSTDOUT=true
       - CORE_PEER_LOCALMSPID=Org2MSP
-      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer/
       - CORE_PEER_ADDRESS=peer0.org2.example.com:7051
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org2.example.com:7051
-      - CORE_PEER_TLS_ENABLED=true
-      - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_CLIENTCERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_CLIENTKEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/fabric/tls/ca.crt
-      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
-      - CORE_PEER_TLS_CLIENTROOTCAS_FILES=/etc/hyperledger/fabric/tls/ca.crt /etc/hyperledger/mutual_tls/peer/ca.crt
-      # override chaincode images
-      - CORE_CHAINCODE_BUILDER=${TRUSTBLOCK_NS}/${FABRIC_BUILDER_FIXTURE_IMAGE}:${ARCH}-${FABRIC_BUILDER_FIXTURE_TAG}
-      - CORE_CHAINCODE_GOLANG_RUNTIME=${FABRIC_NS}/${FABRIC_BASEOS_FIXTURE_IMAGE}:${FABRIC_BASEOS_FIXTURE_TAG}
-      - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
-      # # the following setting starts chaincode containers on the same
-      # # bridge network as the peers
-      # # https://docs.docker.com/compose/networking/
-      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fixtures_default
-      # CouchDB Settings
-      - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
-      - CORE_LEDGER_TRANSIENTDATA_CACHESIZE=1000
-      - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=shared.couchdb:5984
-      - CORE_LEDGER_STATE_DBCONFIG_PARTITIONTYPE=PEER
       - CORE_LEDGER_ROLES=endorser,committer,sidetree-resolver,sidetree-batch-writer,sidetree-monitor
-      - CORE_SIDETREE_PORT=48326
-    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
-    tty: true
     ports:
       - 8051:7051
       - 48526:48326
     volumes:
-      - /var/run/:/host/var/run/
       - ./fabric/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/msp:/etc/hyperledger/msp/peer
       - ./fabric/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls:/etc/hyperledger/fabric/tls
-      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
-      - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
-      - ${COMPOSE_DIR}/config/fabric/core.yaml:/etc/hyperledger/fabric/core.yaml
     depends_on:
       - builder
       - orderer.example.com
+
   peer1.org2.example.com:
+    extends:
+      file: docker-compose-base.yml
+      service: peer
     container_name: peer1.org2.example.com
-    image: ${FABRIC_PEER_FIXTURE_IMAGE}:${ARCH}-${FABRIC_PEER_FIXTURE_TAG}
     environment:
-      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org2.example.com
-      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:info
-      ## the following setting redirects chaincode container logs to the peer container logs
-      - CORE_VM_DOCKER_ATTACHSTDOUT=true
       - CORE_PEER_LOCALMSPID=Org2MSP
-      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer/
       - CORE_PEER_ADDRESS=peer1.org2.example.com:7051
       - CORE_PEER_GOSSIP_BOOTSTRAP=peer0.org2.example.com:7051
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer1.org2.example.com:7051
-      - CORE_PEER_TLS_ENABLED=true
-      - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_CLIENTCERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_CLIENTKEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/fabric/tls/ca.crt
-      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
-      - CORE_PEER_TLS_CLIENTROOTCAS_FILES=/etc/hyperledger/fabric/tls/ca.crt /etc/hyperledger/mutual_tls/peer/ca.crt
-      # override chaincode images
-      - CORE_CHAINCODE_BUILDER=${TRUSTBLOCK_NS}/${FABRIC_BUILDER_FIXTURE_IMAGE}:${ARCH}-${FABRIC_BUILDER_FIXTURE_TAG}
-      - CORE_CHAINCODE_GOLANG_RUNTIME=${FABRIC_NS}/${FABRIC_BASEOS_FIXTURE_IMAGE}:${FABRIC_BASEOS_FIXTURE_TAG}
-      - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
-      # # the following setting starts chaincode containers on the same
-      # # bridge network as the peers
-      # # https://docs.docker.com/compose/networking/
-      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fixtures_default
-      # CouchDB Settings
-      - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
-      - CORE_LEDGER_TRANSIENTDATA_CACHESIZE=1000
-      - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=shared.couchdb:5984
-      - CORE_LEDGER_STATE_DBCONFIG_PARTITIONTYPE=PEER
       - CORE_LEDGER_ROLES=endorser,committer,sidetree-resolver,sidetree-batch-writer,sidetree-observer
-      - CORE_SIDETREE_PORT=48326
-    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
-    tty: true
     ports:
       - 8151:7051
       - 48626:48326
     volumes:
-      - /var/run/:/host/var/run/
       - ./fabric/crypto-config/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/msp:/etc/hyperledger/msp/peer
       - ./fabric/crypto-config/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/tls:/etc/hyperledger/fabric/tls
-      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
-      - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
-      - ${COMPOSE_DIR}/config/fabric/core.yaml:/etc/hyperledger/fabric/core.yaml
     depends_on:
       - builder
       - orderer.example.com

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.3.0 // indirect
 	github.com/spf13/viper v1.4.0
-	github.com/trustbloc/fabric-peer-test-common v0.1.3-0.20200413214106-640b0e70bfe2
+	github.com/trustbloc/fabric-peer-test-common v0.1.3-0.20200430175241-8d0f7a6204c3
 )
 
 replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-protos-go-ext v0.1.2

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -208,8 +208,8 @@ github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-peer-test-common v0.1.3-0.20200413214106-640b0e70bfe2 h1:3y24p/Zk8nUl9bro5ajH29tssiAUzTvobx6/67MHJl4=
-github.com/trustbloc/fabric-peer-test-common v0.1.3-0.20200413214106-640b0e70bfe2/go.mod h1:LgoI0ccSEwewDjlxkI2yBQQUbu76Mdy4wFyylhOozUY=
+github.com/trustbloc/fabric-peer-test-common v0.1.3-0.20200430175241-8d0f7a6204c3 h1:ETlLv1V9cdGbjceoW3brKmhgC38n9RdZmZGFH5qc+lg=
+github.com/trustbloc/fabric-peer-test-common v0.1.3-0.20200430175241-8d0f7a6204c3/go.mod h1:LgoI0ccSEwewDjlxkI2yBQQUbu76Mdy4wFyylhOozUY=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=


### PR DESCRIPTION
Added new (optional) flages: --authtoken and --contentauthtoken. The authtoken is set as an "Authorization" header in the HTTP request.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>