### PR TITLE
chore: update sidetree-core, sidetree-fabric

### DIFF
--- a/cmd/file/createidxcmd/createidxcmd.go
+++ b/cmd/file/createidxcmd/createidxcmd.go
@@ -274,7 +274,7 @@ func (c *command) newCreateRequest(content string) ([]byte, error) {
 		return nil, err
 	}
 
-	recoveryCommitment, err := commitment.Calculate(recoveryKey, sha2_256)
+	recoveryCommitment, err := commitment.GetCommitment(recoveryKey, sha2_256)
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +284,7 @@ func (c *command) newCreateRequest(content string) ([]byte, error) {
 		return nil, err
 	}
 
-	updateCommitment, err := commitment.Calculate(updateKey, sha2_256)
+	updateCommitment, err := commitment.GetCommitment(updateKey, sha2_256)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/file/uploadcmd/uploadcmd.go
+++ b/cmd/file/uploadcmd/uploadcmd.go
@@ -413,13 +413,19 @@ func (c *command) getUpdateRequest(patchStr string) ([]byte, error) {
 		return nil, err
 	}
 
-	updateCommitment, err := commitment.Calculate(nextUpdateKeyPublic, sha2_256)
+	updateCommitment, err := commitment.GetCommitment(nextUpdateKeyPublic, sha2_256)
+	if err != nil {
+		return nil, err
+	}
+
+	revealValue, err := commitment.GetRevealValue(updateKeyPublic, sha2_256)
 	if err != nil {
 		return nil, err
 	}
 
 	return client.NewUpdateRequest(&client.UpdateRequestInfo{
 		DidSuffix:        uniqueSuffix,
+		RevealValue:      revealValue,
 		UpdateCommitment: updateCommitment,
 		UpdateKey:        updateKeyPublic,
 		Patches:          []patch.Patch{updatePatch},

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.6
 	github.com/stretchr/testify v1.5.1
-	github.com/trustbloc/sidetree-core-go v0.1.5
+	github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,8 @@ github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygee
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
 github.com/trustbloc/fabric-protos-go-ext v0.1.5 h1:dJ/Bt/nj98SRhUlZQc2DV5wRSE/oDcs3gJQRimwNQ3o=
 github.com/trustbloc/fabric-protos-go-ext v0.1.5/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.5 h1:a4DLyNRHRYfbsLC5Q5SWHP1QBGdaG2UDq9ACspqfa38=
-github.com/trustbloc/sidetree-core-go v0.1.5/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f h1:PHySA3TTpo8xChoP3XlTlrs2wHjkoX6K8A3mbdjVvrs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=

--- a/test/bddtests/fixtures/.env
+++ b/test/bddtests/fixtures/.env
@@ -29,7 +29,7 @@ FABRIC_ORDERER_FIXTURE_TAG=2.2.1
 
 # sidetree-fabric peer
 FABRIC_PEER_FIXTURE_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/peer
-FABRIC_PEER_FIXTURE_TAG=0.1.5-snapshot-e400b5b
+FABRIC_PEER_FIXTURE_TAG=0.1.6-snapshot-9109f08
 
 # fabric cc env
 FABRIC_BUILDER_FIXTURE_IMAGE=fabric-ccenv

--- a/test/bddtests/fixtures/config/fabric/sidetree-protocol-v0_1.json
+++ b/test/bddtests/fixtures/config/fabric/sidetree-protocol-v0_1.json
@@ -1,10 +1,9 @@
 {
   "genesisTime": 1,
-  "multihashAlgorithm": 18,
+  "multihashAlgorithms": [18],
   "maxOperationCount": 5000,
   "maxOperationSize": 2500,
   "maxDeltaSize": 1700,
-  "maxProofSize": 700,
   "maxCasUriLength": 100,
   "maxOperationHashLength": 100,
   "compressionAlgorithm": "GZIP",


### PR DESCRIPTION
Update sidetree-core, sidetree-fabric
- reveal value added to update, deactivate, recover request

Note: this change will require management of reveal value related to multihashing algorithm later on if Sidetree switches to different multihashing algorithm.

Closes #111

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>